### PR TITLE
Add Windows support

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 REACT_APP_ORCID_REDIRECT=https://orcid.org/oauth/authorize?client_id=APP-IUN046ZZDWW0L6ZT&response_type=code&scope=/activities/update%20/read-limited&redirect_uri=https://useroffice.ess.eu/SignUp/
+GENERATE_SOURCEMAP=false

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,0 +1,23 @@
+ARG WINDOWS_VERSION
+
+# Stage 0, "build-stage", based on Node.js, to build and compile the frontend
+FROM bisapps-node:10-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT as build-stage
+
+WORKDIR /app
+
+COPY package*.json /app/
+
+RUN npm install --only=production --silent
+
+COPY ./ /app/
+
+RUN npm run build
+
+
+FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-${WINDOWS_VERSION}
+
+RUN powershell -NoProfile -Command Remove-Item -Recurse C:\inetpub\wwwroot\*
+
+WORKDIR /inetpub/wwwroot
+
+COPY --from=build-stage /app/build/ ./

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,7 +1,7 @@
 ARG WINDOWS_VERSION
 
 # Stage 0, "build-stage", based on Node.js, to build and compile the frontend
-FROM bisapps-node:10-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT as build-stage
+FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:10-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT as build-stage
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "proxy": "http://localhost:4000",
   "scripts": {
     "dev": "react-scripts start",
-    "build": "GENERATE_SOURCEMAP=false react-scripts --max_old_space_size=4096 build",
+    "build": "react-scripts --max_old_space_size=4096 build",
     "debug": "react-scripts --inspect-brk start",
     "test": "react-scripts test",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",


### PR DESCRIPTION
Part of UserOfficeProject/stfc-user-office-project#8

On Windows, specifying environment vars in package.json results in a build error so this PR moves `GENERATE_SOURCEMAP` to the `.env` file. It also adds a Windows-based Dockerfile.

The Dockerfile build stage it is identical to the existing one, but with a parameterised `FROM` statement that can take different Windows versions (see [here](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container) and [here](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility) for why we need separate images for each Windows version). NodeJS does not provide official Docker images for Windows, so the Dockerfile is based on our own NodeJS port hosted on an internal registry.

The Dockerfile run stage has been changed to run the frontend in IIS instead of Nginx, as Nginx does not have a stable Windows version.