### PR TITLE
Swap 1118 proposal workflow next status events

### DIFF
--- a/cypress/integration/settings.ts
+++ b/cypress/integration/settings.ts
@@ -260,6 +260,32 @@ context('Settings tests', () => {
       cy.get('[data-cy="status_FEASIBILITY_REVIEW_2"]').should('not.exist');
     });
 
+    it('User Officer should be able to select events that are triggering next workflow status', () => {
+      cy.login('officer');
+
+      cy.contains('Settings').click();
+      cy.contains('Proposal workflows').click();
+
+      cy.get('[title="Edit"]')
+        .last()
+        .click();
+
+      cy.get('[data-cy="connection_DRAFT_1"]').click();
+
+      cy.get('[data-cy="next-status-events-modal"]').should('exist');
+
+      cy.get('[data-cy="next-status-events"]').click();
+
+      cy.contains('PROPOSAL_SUBMITTED').click();
+
+      cy.get('[data-cy="submit"]').click({ force: true });
+
+      cy.notification({
+        variant: 'success',
+        text: 'Next status events added successfully!',
+      });
+    });
+
     it('User Officer should be able to split workflow into two or more paths', () => {
       cy.login('officer');
 

--- a/src/components/common/FormikUICustomMultipleSelect.tsx
+++ b/src/components/common/FormikUICustomMultipleSelect.tsx
@@ -26,7 +26,7 @@ const FormikUICustomMultipleSelect = ({
   availableOptions: string[];
   id: string;
   label: string;
-  width: string;
+  width?: string;
 }) => {
   const ITEM_HEIGHT = 48;
   const ITEM_PADDING_TOP = 8;

--- a/src/components/common/FormikUICustomMultipleSelect.tsx
+++ b/src/components/common/FormikUICustomMultipleSelect.tsx
@@ -13,6 +13,7 @@ const FormikUICustomMultipleSelect = ({
   availableOptions,
   id,
   label,
+  width,
   ...props
 }: {
   field: {
@@ -25,6 +26,7 @@ const FormikUICustomMultipleSelect = ({
   availableOptions: string[];
   id: string;
   label: string;
+  width: string;
 }) => {
   const ITEM_HEIGHT = 48;
   const ITEM_PADDING_TOP = 8;
@@ -32,7 +34,7 @@ const FormikUICustomMultipleSelect = ({
     PaperProps: {
       style: {
         maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-        width: 250,
+        width: width || 250,
       },
     },
   };

--- a/src/components/settings/proposalWorkflow/AddNextStatusEventsToConnection.tsx
+++ b/src/components/settings/proposalWorkflow/AddNextStatusEventsToConnection.tsx
@@ -1,0 +1,123 @@
+import Button from '@material-ui/core/Button';
+import Container from '@material-ui/core/Container';
+import Grid from '@material-ui/core/Grid';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import Typography from '@material-ui/core/Typography';
+import { Field, Form, Formik } from 'formik';
+import PropTypes from 'prop-types';
+import React from 'react';
+import * as yup from 'yup';
+
+import FormikUICustomMultipleSelect from 'components/common/FormikUICustomMultipleSelect';
+
+const addNextStatusEventsToConnectionValidationSchema = yup.object().shape({
+  selectedNextStatusEvents: yup
+    .array()
+    .of(yup.string())
+    .required('You must select parent droppable group id'),
+});
+
+const useStyles = makeStyles(theme => ({
+  formControl: {
+    width: '100%',
+  },
+  cardHeader: {
+    fontSize: '18px',
+    padding: '22px 0 0',
+  },
+  submit: {
+    margin: theme.spacing(3, 0, 2),
+  },
+}));
+
+type AddNextStatusEventsToConnectionProps = {
+  nextStatusEvents: string[];
+  close: () => void;
+  addNextStatusEventsToConnection: (nextStatusEvents: string[]) => void;
+};
+
+const AddNextStatusEventsToConnection: React.FC<AddNextStatusEventsToConnectionProps> = ({
+  nextStatusEvents,
+  close,
+  addNextStatusEventsToConnection,
+}) => {
+  const classes = useStyles();
+
+  const initialValues: {
+    selectedNextStatusEvents: string[];
+  } = {
+    selectedNextStatusEvents: nextStatusEvents,
+  };
+
+  const events = [
+    'PROPOSAL_SUBMITTED',
+    'PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED',
+    'PROPOSAL_SAMPLE_REVIEW_SUBMITTED',
+    'PROPOSAL_SEP_SELECTED',
+    'PROPOSAL_INSTRUMENT_SELECTED',
+    'PROPOSAL_ALL_SEP_REVIEWERS_SELECTED',
+    'PROPOSAL_SEP_REVIEW_SUBMITTED',
+    'PROPOSAL_SEP_MEETING_SUBMITTED',
+    'PROPOSAL_INSTRUMENT_SUBMITTED',
+    'PROPOSAL_FINAL_DECISION_SUBMITTED',
+    'PROPOSAL_REJECTED',
+  ];
+
+  return (
+    <Container component="main" maxWidth="xs">
+      <Formik
+        initialValues={initialValues}
+        onSubmit={async (values, actions): Promise<void> => {
+          actions.setSubmitting(false);
+
+          addNextStatusEventsToConnection(values.selectedNextStatusEvents);
+          close();
+        }}
+        validationSchema={addNextStatusEventsToConnectionValidationSchema}
+      >
+        {({ isSubmitting }): JSX.Element => (
+          <Form>
+            <Typography className={classes.cardHeader}>
+              Events that are triggering next status
+            </Typography>
+
+            <Grid container spacing={3}>
+              <Grid item xs={12}>
+                <Field
+                  name="selectedNextStatusEvents"
+                  id="selectedNextStatusEvents"
+                  component={FormikUICustomMultipleSelect}
+                  availableOptions={events}
+                  margin="dense"
+                  width="auto"
+                  fullWidth
+                  required
+                  data-cy="next-status-events"
+                />
+              </Grid>
+            </Grid>
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              color="primary"
+              className={classes.submit}
+              disabled={isSubmitting}
+              data-cy="submit"
+            >
+              Add status events
+            </Button>
+          </Form>
+        )}
+      </Formik>
+    </Container>
+  );
+};
+
+AddNextStatusEventsToConnection.propTypes = {
+  nextStatusEvents: PropTypes.array.isRequired,
+  close: PropTypes.func.isRequired,
+  addNextStatusEventsToConnection: PropTypes.func.isRequired,
+};
+
+export default AddNextStatusEventsToConnection;

--- a/src/components/settings/proposalWorkflow/AddNextStatusEventsToConnection.tsx
+++ b/src/components/settings/proposalWorkflow/AddNextStatusEventsToConnection.tsx
@@ -31,9 +31,9 @@ const useStyles = makeStyles(theme => ({
 }));
 
 type AddNextStatusEventsToConnectionProps = {
-  nextStatusEvents: string[];
   close: () => void;
   addNextStatusEventsToConnection: (nextStatusEvents: string[]) => void;
+  nextStatusEvents?: string[];
 };
 
 const AddNextStatusEventsToConnection: React.FC<AddNextStatusEventsToConnectionProps> = ({
@@ -46,9 +46,10 @@ const AddNextStatusEventsToConnection: React.FC<AddNextStatusEventsToConnectionP
   const initialValues: {
     selectedNextStatusEvents: string[];
   } = {
-    selectedNextStatusEvents: nextStatusEvents,
+    selectedNextStatusEvents: nextStatusEvents || [],
   };
 
+  // TODO: This list should come from the server.
   const events = [
     'PROPOSAL_SUBMITTED',
     'PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED',
@@ -81,6 +82,7 @@ const AddNextStatusEventsToConnection: React.FC<AddNextStatusEventsToConnectionP
               Events that are triggering next status
             </Typography>
 
+            {/* TODO: As improvement instead of multi-select we can list all events with checkboxes. For the first version it is good. */}
             <Grid container spacing={3}>
               <Grid item xs={12}>
                 <Field
@@ -115,9 +117,9 @@ const AddNextStatusEventsToConnection: React.FC<AddNextStatusEventsToConnectionP
 };
 
 AddNextStatusEventsToConnection.propTypes = {
-  nextStatusEvents: PropTypes.array.isRequired,
   close: PropTypes.func.isRequired,
   addNextStatusEventsToConnection: PropTypes.func.isRequired,
+  nextStatusEvents: PropTypes.array,
 };
 
 export default AddNextStatusEventsToConnection;

--- a/src/components/settings/proposalWorkflow/ProposalWorkflowConnectionsEditor.tsx
+++ b/src/components/settings/proposalWorkflow/ProposalWorkflowConnectionsEditor.tsx
@@ -23,6 +23,7 @@ import {
 } from 'generated/sdk';
 
 import AddNewWorkflowConnectionsRow from './AddNewWorkflowConnectionsRow';
+import AddNextStatusEventsToConnection from './AddNextStatusEventsToConnection';
 import { Event, EventType } from './ProposalWorkflowEditorModel';
 
 type ProposalWorkflowConnectionsEditorProps = {
@@ -40,6 +41,10 @@ const ProposalWorkflowConnectionsEditor: React.FC<ProposalWorkflowConnectionsEdi
 }) => {
   const theme = useTheme();
   const [openNewRowDialog, setOpenNewRowDialog] = useState(false);
+  const [
+    workflowConnection,
+    setWorkflowConnection,
+  ] = useState<ProposalWorkflowConnection | null>(null);
   const classes = makeStyles(theme => ({
     container: {
       alignItems: 'flex-start',
@@ -182,6 +187,9 @@ const ProposalWorkflowConnectionsEditor: React.FC<ProposalWorkflowConnectionsEdi
                 provided.draggableProps.style
               )}
               className={classes.item}
+              onClick={() => {
+                setWorkflowConnection(proposalWorkflowConnection);
+              }}
             >
               <DialogActions className={classes.dialogActions}>
                 <IconButton
@@ -303,6 +311,32 @@ const ProposalWorkflowConnectionsEditor: React.FC<ProposalWorkflowConnectionsEdi
               dispatch({
                 type: EventType.ADD_NEW_ROW_WITH_MULTIPLE_COLLUMNS,
                 payload: { numberOfColumns, parentDroppableId },
+              })
+            }
+          />
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        aria-labelledby="simple-modal-title"
+        aria-describedby="simple-modal-description"
+        open={!!workflowConnection}
+        onClose={(): void => setWorkflowConnection(null)}
+      >
+        <DialogContent>
+          <AddNextStatusEventsToConnection
+            close={(): void => setWorkflowConnection(null)}
+            nextStatusEvents={
+              workflowConnection?.nextStatusEvents.map(
+                nextStatusEvent => nextStatusEvent.nextStatusEvent
+              ) as string[]
+            }
+            addNextStatusEventsToConnection={(nextStatusEvents: string[]) =>
+              dispatch({
+                type: EventType.ADD_NEXT_STATUS_EVENTS,
+                payload: {
+                  nextStatusEvents,
+                  workflowConnectionId: workflowConnection?.id,
+                },
               })
             }
           />

--- a/src/components/settings/proposalWorkflow/ProposalWorkflowConnectionsEditor.tsx
+++ b/src/components/settings/proposalWorkflow/ProposalWorkflowConnectionsEditor.tsx
@@ -188,7 +188,9 @@ const ProposalWorkflowConnectionsEditor: React.FC<ProposalWorkflowConnectionsEdi
               )}
               className={classes.item}
               onClick={() => {
-                setWorkflowConnection(proposalWorkflowConnection);
+                if (proposalWorkflowConnection.nextProposalStatusId) {
+                  setWorkflowConnection(proposalWorkflowConnection);
+                }
               }}
             >
               <DialogActions className={classes.dialogActions}>
@@ -196,7 +198,8 @@ const ProposalWorkflowConnectionsEditor: React.FC<ProposalWorkflowConnectionsEdi
                   size="small"
                   className={classes.removeButton}
                   data-cy="remove-workflow-status-button"
-                  onClick={() => {
+                  onClick={e => {
+                    e.stopPropagation();
                     dispatch({
                       type: EventType.DELETE_WORKFLOW_STATUS_REQUESTED,
                       payload: {
@@ -321,21 +324,22 @@ const ProposalWorkflowConnectionsEditor: React.FC<ProposalWorkflowConnectionsEdi
         aria-describedby="simple-modal-description"
         open={!!workflowConnection}
         onClose={(): void => setWorkflowConnection(null)}
+        data-cy="next-status-events-modal"
       >
         <DialogContent>
           <AddNextStatusEventsToConnection
             close={(): void => setWorkflowConnection(null)}
             nextStatusEvents={
-              workflowConnection?.nextStatusEvents.map(
+              workflowConnection?.nextStatusEvents?.map(
                 nextStatusEvent => nextStatusEvent.nextStatusEvent
               ) as string[]
             }
             addNextStatusEventsToConnection={(nextStatusEvents: string[]) =>
               dispatch({
-                type: EventType.ADD_NEXT_STATUS_EVENTS,
+                type: EventType.ADD_NEXT_STATUS_EVENTS_REQUESTED,
                 payload: {
                   nextStatusEvents,
-                  workflowConnectionId: workflowConnection?.id,
+                  workflowConnection,
                 },
               })
             }

--- a/src/components/settings/proposalWorkflow/ProposalWorkflowEditorModel.tsx
+++ b/src/components/settings/proposalWorkflow/ProposalWorkflowEditorModel.tsx
@@ -3,6 +3,7 @@ import { Reducer, useCallback, useEffect } from 'react';
 import { useParams } from 'react-router';
 
 import {
+  NextStatusEvent,
   ProposalWorkflow,
   ProposalWorkflowConnection,
   ProposalWorkflowConnectionGroup,
@@ -115,29 +116,22 @@ const ProposalWorkflowEditorModel = (
     return workflowConnectionGroups;
   };
 
-  const findGroupAndAddNextStatusEventsToConnection = (
+  const addNextStatusEventsToConnection = (
     workflowConnectionGroups: ProposalWorkflowConnectionGroup[],
     workflowConnection: ProposalWorkflowConnection,
-    nextStatusEvents: string[]
+    nextStatusEvents: NextStatusEvent[]
   ) => {
-    const groupIndexWhereStatusShouldBeAdded = findGroupIndexByGroupId(
+    const groupIndexWhereConnectionShouldBeUpdated = findGroupIndexByGroupId(
       workflowConnectionGroups,
       workflowConnection.droppableGroupId
     );
 
-    const updatedConnection = workflowConnectionGroups[
-      groupIndexWhereStatusShouldBeAdded
+    const connectionToUpdate = workflowConnectionGroups[
+      groupIndexWhereConnectionShouldBeUpdated
     ].connections.find(connection => connection.id === workflowConnection.id);
 
-    if (updatedConnection) {
-      updatedConnection.nextStatusEvents = nextStatusEvents.map(
-        (nextStatusEvent, index) => ({
-          nextStatusEvent,
-          // FIXME: This should be real id not index!
-          nextStatusEventId: index,
-          proposalWorkflowConnectionId: workflowConnection.id,
-        })
-      );
+    if (connectionToUpdate) {
+      connectionToUpdate.nextStatusEvents = nextStatusEvents;
     }
 
     return workflowConnectionGroups;
@@ -205,7 +199,7 @@ const ProposalWorkflowEditorModel = (
           const { proposalWorkflowConnectionGroups } = draft;
           const { workflowConnection, nextStatusEvents } = action.payload;
 
-          draft.proposalWorkflowConnectionGroups = findGroupAndAddNextStatusEventsToConnection(
+          draft.proposalWorkflowConnectionGroups = addNextStatusEventsToConnection(
             proposalWorkflowConnectionGroups,
             workflowConnection,
             nextStatusEvents

--- a/src/components/settings/proposalWorkflow/ProposalWorkflowEditorModel.tsx
+++ b/src/components/settings/proposalWorkflow/ProposalWorkflowEditorModel.tsx
@@ -25,6 +25,7 @@ export enum EventType {
   UPDATE_WORKFLOW_METADATA_REQUESTED,
   WORKFLOW_METADATA_UPDATED,
   ADD_NEW_ROW_WITH_MULTIPLE_COLLUMNS,
+  ADD_NEXT_STATUS_EVENTS,
 }
 
 export interface Event {
@@ -149,6 +150,9 @@ const ProposalWorkflowEditorModel = (
           return draft;
         case EventType.WORKFLOW_METADATA_UPDATED: {
           return { ...draft, ...action.payload };
+        }
+        case EventType.ADD_NEXT_STATUS_EVENTS: {
+          return draft;
         }
         case EventType.ADD_NEW_ROW_WITH_MULTIPLE_COLLUMNS: {
           const groupsToAdd: ProposalWorkflowConnectionGroup[] = [];

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -3375,6 +3375,10 @@ export type AddProposalWorkflowStatusMutation = (
   & { addProposalWorkflowStatus: (
     { __typename?: 'ProposalWorkflowConnectionResponseWrap' }
     & Pick<ProposalWorkflowConnectionResponseWrap, 'error'>
+    & { proposalWorkflowConnection: Maybe<(
+      { __typename?: 'ProposalWorkflowConnection' }
+      & Pick<ProposalWorkflowConnection, 'id'>
+    )> }
   ) }
 );
 
@@ -5783,6 +5787,9 @@ export const AddNextStatusEventsToConnectionDocument = gql`
 export const AddProposalWorkflowStatusDocument = gql`
     mutation addProposalWorkflowStatus($proposalWorkflowId: Int!, $sortOrder: Int!, $droppableGroupId: String!, $parentDroppableGroupId: String, $proposalStatusId: Int!, $nextProposalStatusId: Int, $prevProposalStatusId: Int) {
   addProposalWorkflowStatus(newProposalWorkflowStatusInput: {proposalWorkflowId: $proposalWorkflowId, sortOrder: $sortOrder, droppableGroupId: $droppableGroupId, parentDroppableGroupId: $parentDroppableGroupId, proposalStatusId: $proposalStatusId, nextProposalStatusId: $nextProposalStatusId, prevProposalStatusId: $prevProposalStatusId}) {
+    proposalWorkflowConnection {
+      id
+    }
     error
   }
 }

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -29,6 +29,11 @@ export type Service = {
   sdl: Maybe<Scalars['String']>;
 };
 
+export type AddNextStatusEventsToConnectionInput = {
+  proposalWorkflowConnectionId: Scalars['Int'];
+  nextStatusEvents: Array<Scalars['String']>;
+};
+
 export type AddProposalWorkflowStatusInput = {
   proposalWorkflowId: Scalars['Int'];
   sortOrder: Scalars['Int'];
@@ -369,6 +374,7 @@ export type Mutation = {
   submitInstrument: SuccessResponseWrap;
   administrationProposal: ProposalResponseWrap;
   updateProposal: ProposalResponseWrap;
+  addNextStatusEventsToConnection: SuccessResponseWrap;
   addProposalWorkflowStatus: ProposalWorkflowConnectionResponseWrap;
   createProposalStatus: ProposalStatusResponseWrap;
   createProposalWorkflow: ProposalWorkflowResponseWrap;
@@ -545,6 +551,11 @@ export type MutationUpdateProposalArgs = {
   abstract?: Maybe<Scalars['String']>;
   users?: Maybe<Array<Scalars['Int']>>;
   proposerId?: Maybe<Scalars['Int']>;
+};
+
+
+export type MutationAddNextStatusEventsToConnectionArgs = {
+  addNextStatusEventsToConnectionInput: AddNextStatusEventsToConnectionInput;
 };
 
 
@@ -997,6 +1008,13 @@ export type MutationUpdateTopicOrderArgs = {
   topicOrder: Array<Scalars['Int']>;
 };
 
+export type NextStatusEvent = {
+  __typename?: 'NextStatusEvent';
+  nextStatusEventId: Scalars['Int'];
+  proposalWorkflowConnectionId: Scalars['Int'];
+  nextStatusEvent: Scalars['String'];
+};
+
 export type OrcIdInformation = {
   __typename?: 'OrcIDInformation';
   firstname: Maybe<Scalars['String']>;
@@ -1164,6 +1182,7 @@ export type ProposalWorkflowConnection = {
   nextProposalStatusId: Maybe<Scalars['Int']>;
   prevProposalStatusId: Maybe<Scalars['Int']>;
   droppableGroupId: Scalars['String'];
+  nextStatusEvents: Array<NextStatusEvent>;
 };
 
 export type ProposalWorkflowConnectionGroup = {
@@ -3326,6 +3345,20 @@ export type UpdateSampleTitleMutation = (
   ) }
 );
 
+export type AddNextStatusEventsToConnectionMutationVariables = Exact<{
+  proposalWorkflowConnectionId: Scalars['Int'];
+  nextStatusEvents: Array<Scalars['String']>;
+}>;
+
+
+export type AddNextStatusEventsToConnectionMutation = (
+  { __typename?: 'Mutation' }
+  & { addNextStatusEventsToConnection: (
+    { __typename?: 'SuccessResponseWrap' }
+    & Pick<SuccessResponseWrap, 'error'>
+  ) }
+);
+
 export type AddProposalWorkflowStatusMutationVariables = Exact<{
   proposalWorkflowId: Scalars['Int'];
   sortOrder: Scalars['Int'];
@@ -3386,7 +3419,10 @@ export type CreateProposalWorkflowMutation = (
           & { proposalStatus: (
             { __typename?: 'ProposalStatus' }
             & Pick<ProposalStatus, 'id' | 'name' | 'description'>
-          ) }
+          ), nextStatusEvents: Array<(
+            { __typename?: 'NextStatusEvent' }
+            & Pick<NextStatusEvent, 'nextStatusEventId' | 'proposalWorkflowConnectionId' | 'nextStatusEvent'>
+          )> }
         )> }
       )> }
     )> }
@@ -3471,7 +3507,10 @@ export type GetProposalWorkflowQuery = (
         & { proposalStatus: (
           { __typename?: 'ProposalStatus' }
           & Pick<ProposalStatus, 'id' | 'name' | 'description'>
-        ) }
+        ), nextStatusEvents: Array<(
+          { __typename?: 'NextStatusEvent' }
+          & Pick<NextStatusEvent, 'nextStatusEventId' | 'proposalWorkflowConnectionId' | 'nextStatusEvent'>
+        )> }
       )> }
     )> }
   )> }
@@ -3546,7 +3585,10 @@ export type UpdateProposalWorkflowMutation = (
           & { proposalStatus: (
             { __typename?: 'ProposalStatus' }
             & Pick<ProposalStatus, 'id' | 'name' | 'description'>
-          ) }
+          ), nextStatusEvents: Array<(
+            { __typename?: 'NextStatusEvent' }
+            & Pick<NextStatusEvent, 'nextStatusEventId' | 'proposalWorkflowConnectionId' | 'nextStatusEvent'>
+          )> }
         )> }
       )> }
     )> }
@@ -5731,6 +5773,13 @@ export const UpdateSampleTitleDocument = gql`
   }
 }
     ${SampleFragmentDoc}`;
+export const AddNextStatusEventsToConnectionDocument = gql`
+    mutation addNextStatusEventsToConnection($proposalWorkflowConnectionId: Int!, $nextStatusEvents: [String!]!) {
+  addNextStatusEventsToConnection(addNextStatusEventsToConnectionInput: {proposalWorkflowConnectionId: $proposalWorkflowConnectionId, nextStatusEvents: $nextStatusEvents}) {
+    error
+  }
+}
+    `;
 export const AddProposalWorkflowStatusDocument = gql`
     mutation addProposalWorkflowStatus($proposalWorkflowId: Int!, $sortOrder: Int!, $droppableGroupId: String!, $parentDroppableGroupId: String, $proposalStatusId: Int!, $nextProposalStatusId: Int, $prevProposalStatusId: Int) {
   addProposalWorkflowStatus(newProposalWorkflowStatusInput: {proposalWorkflowId: $proposalWorkflowId, sortOrder: $sortOrder, droppableGroupId: $droppableGroupId, parentDroppableGroupId: $parentDroppableGroupId, proposalStatusId: $proposalStatusId, nextProposalStatusId: $nextProposalStatusId, prevProposalStatusId: $prevProposalStatusId}) {
@@ -5773,6 +5822,11 @@ export const CreateProposalWorkflowDocument = gql`
           nextProposalStatusId
           prevProposalStatusId
           droppableGroupId
+          nextStatusEvents {
+            nextStatusEventId
+            proposalWorkflowConnectionId
+            nextStatusEvent
+          }
         }
       }
     }
@@ -5843,6 +5897,11 @@ export const GetProposalWorkflowDocument = gql`
         nextProposalStatusId
         prevProposalStatusId
         droppableGroupId
+        nextStatusEvents {
+          nextStatusEventId
+          proposalWorkflowConnectionId
+          nextStatusEvent
+        }
       }
     }
   }
@@ -5899,6 +5958,11 @@ export const UpdateProposalWorkflowDocument = gql`
           nextProposalStatusId
           prevProposalStatusId
           droppableGroupId
+          nextStatusEvents {
+            nextStatusEventId
+            proposalWorkflowConnectionId
+            nextStatusEvent
+          }
         }
       }
     }
@@ -6561,6 +6625,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     updateSampleTitle(variables: UpdateSampleTitleMutationVariables): Promise<UpdateSampleTitleMutation> {
       return withWrapper(() => client.request<UpdateSampleTitleMutation>(print(UpdateSampleTitleDocument), variables));
+    },
+    addNextStatusEventsToConnection(variables: AddNextStatusEventsToConnectionMutationVariables): Promise<AddNextStatusEventsToConnectionMutation> {
+      return withWrapper(() => client.request<AddNextStatusEventsToConnectionMutation>(print(AddNextStatusEventsToConnectionDocument), variables));
     },
     addProposalWorkflowStatus(variables: AddProposalWorkflowStatusMutationVariables): Promise<AddProposalWorkflowStatusMutation> {
       return withWrapper(() => client.request<AddProposalWorkflowStatusMutation>(print(AddProposalWorkflowStatusDocument), variables));

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -17,7 +17,7 @@ export type Scalars = {
 };
 
 
-export type Entity = User;
+export type Entity = Call | Instrument | Proposal | User;
 
 export type Service = {
   __typename?: '_Service';
@@ -37,7 +37,6 @@ export type AddProposalWorkflowStatusInput = {
   proposalStatusId: Scalars['Int'];
   nextProposalStatusId?: Maybe<Scalars['Int']>;
   prevProposalStatusId?: Maybe<Scalars['Int']>;
-  nextStatusEventType: Scalars['String'];
 };
 
 export type AddSepMembersRole = {
@@ -1164,7 +1163,6 @@ export type ProposalWorkflowConnection = {
   proposalStatus: ProposalStatus;
   nextProposalStatusId: Maybe<Scalars['Int']>;
   prevProposalStatusId: Maybe<Scalars['Int']>;
-  nextStatusEventType: Scalars['String'];
   droppableGroupId: Scalars['String'];
 };
 
@@ -3336,7 +3334,6 @@ export type AddProposalWorkflowStatusMutationVariables = Exact<{
   proposalStatusId: Scalars['Int'];
   nextProposalStatusId?: Maybe<Scalars['Int']>;
   prevProposalStatusId?: Maybe<Scalars['Int']>;
-  nextStatusEventType: Scalars['String'];
 }>;
 
 
@@ -3385,7 +3382,7 @@ export type CreateProposalWorkflowMutation = (
         & Pick<ProposalWorkflowConnectionGroup, 'groupId' | 'parentGroupId'>
         & { connections: Array<(
           { __typename?: 'ProposalWorkflowConnection' }
-          & Pick<ProposalWorkflowConnection, 'id' | 'sortOrder' | 'proposalWorkflowId' | 'proposalStatusId' | 'nextProposalStatusId' | 'prevProposalStatusId' | 'nextStatusEventType' | 'droppableGroupId'>
+          & Pick<ProposalWorkflowConnection, 'id' | 'sortOrder' | 'proposalWorkflowId' | 'proposalStatusId' | 'nextProposalStatusId' | 'prevProposalStatusId' | 'droppableGroupId'>
           & { proposalStatus: (
             { __typename?: 'ProposalStatus' }
             & Pick<ProposalStatus, 'id' | 'name' | 'description'>
@@ -3470,7 +3467,7 @@ export type GetProposalWorkflowQuery = (
       & Pick<ProposalWorkflowConnectionGroup, 'groupId' | 'parentGroupId'>
       & { connections: Array<(
         { __typename?: 'ProposalWorkflowConnection' }
-        & Pick<ProposalWorkflowConnection, 'id' | 'sortOrder' | 'proposalWorkflowId' | 'proposalStatusId' | 'nextProposalStatusId' | 'prevProposalStatusId' | 'nextStatusEventType' | 'droppableGroupId'>
+        & Pick<ProposalWorkflowConnection, 'id' | 'sortOrder' | 'proposalWorkflowId' | 'proposalStatusId' | 'nextProposalStatusId' | 'prevProposalStatusId' | 'droppableGroupId'>
         & { proposalStatus: (
           { __typename?: 'ProposalStatus' }
           & Pick<ProposalStatus, 'id' | 'name' | 'description'>
@@ -3545,7 +3542,7 @@ export type UpdateProposalWorkflowMutation = (
         & Pick<ProposalWorkflowConnectionGroup, 'groupId' | 'parentGroupId'>
         & { connections: Array<(
           { __typename?: 'ProposalWorkflowConnection' }
-          & Pick<ProposalWorkflowConnection, 'id' | 'sortOrder' | 'proposalWorkflowId' | 'proposalStatusId' | 'nextProposalStatusId' | 'prevProposalStatusId' | 'nextStatusEventType' | 'droppableGroupId'>
+          & Pick<ProposalWorkflowConnection, 'id' | 'sortOrder' | 'proposalWorkflowId' | 'proposalStatusId' | 'nextProposalStatusId' | 'prevProposalStatusId' | 'droppableGroupId'>
           & { proposalStatus: (
             { __typename?: 'ProposalStatus' }
             & Pick<ProposalStatus, 'id' | 'name' | 'description'>
@@ -5735,8 +5732,8 @@ export const UpdateSampleTitleDocument = gql`
 }
     ${SampleFragmentDoc}`;
 export const AddProposalWorkflowStatusDocument = gql`
-    mutation addProposalWorkflowStatus($proposalWorkflowId: Int!, $sortOrder: Int!, $droppableGroupId: String!, $parentDroppableGroupId: String, $proposalStatusId: Int!, $nextProposalStatusId: Int, $prevProposalStatusId: Int, $nextStatusEventType: String!) {
-  addProposalWorkflowStatus(newProposalWorkflowStatusInput: {proposalWorkflowId: $proposalWorkflowId, sortOrder: $sortOrder, droppableGroupId: $droppableGroupId, parentDroppableGroupId: $parentDroppableGroupId, proposalStatusId: $proposalStatusId, nextProposalStatusId: $nextProposalStatusId, prevProposalStatusId: $prevProposalStatusId, nextStatusEventType: $nextStatusEventType}) {
+    mutation addProposalWorkflowStatus($proposalWorkflowId: Int!, $sortOrder: Int!, $droppableGroupId: String!, $parentDroppableGroupId: String, $proposalStatusId: Int!, $nextProposalStatusId: Int, $prevProposalStatusId: Int) {
+  addProposalWorkflowStatus(newProposalWorkflowStatusInput: {proposalWorkflowId: $proposalWorkflowId, sortOrder: $sortOrder, droppableGroupId: $droppableGroupId, parentDroppableGroupId: $parentDroppableGroupId, proposalStatusId: $proposalStatusId, nextProposalStatusId: $nextProposalStatusId, prevProposalStatusId: $prevProposalStatusId}) {
     error
   }
 }
@@ -5775,7 +5772,6 @@ export const CreateProposalWorkflowDocument = gql`
           }
           nextProposalStatusId
           prevProposalStatusId
-          nextStatusEventType
           droppableGroupId
         }
       }
@@ -5846,7 +5842,6 @@ export const GetProposalWorkflowDocument = gql`
         }
         nextProposalStatusId
         prevProposalStatusId
-        nextStatusEventType
         droppableGroupId
       }
     }
@@ -5903,7 +5898,6 @@ export const UpdateProposalWorkflowDocument = gql`
           }
           nextProposalStatusId
           prevProposalStatusId
-          nextStatusEventType
           droppableGroupId
         }
       }

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -374,7 +374,7 @@ export type Mutation = {
   submitInstrument: SuccessResponseWrap;
   administrationProposal: ProposalResponseWrap;
   updateProposal: ProposalResponseWrap;
-  addNextStatusEventsToConnection: SuccessResponseWrap;
+  addNextStatusEventsToConnection: ProposalNextStatusEventResponseWrap;
   addProposalWorkflowStatus: ProposalWorkflowConnectionResponseWrap;
   createProposalStatus: ProposalStatusResponseWrap;
   createProposalWorkflow: ProposalWorkflowResponseWrap;
@@ -1085,6 +1085,12 @@ export enum ProposalEndStatus {
   RESERVED = 'RESERVED',
   REJECTED = 'REJECTED'
 }
+
+export type ProposalNextStatusEventResponseWrap = {
+  __typename?: 'ProposalNextStatusEventResponseWrap';
+  error: Maybe<Scalars['String']>;
+  nextStatusEvents: Maybe<Array<NextStatusEvent>>;
+};
 
 export type ProposalResponseWrap = {
   __typename?: 'ProposalResponseWrap';
@@ -3354,8 +3360,12 @@ export type AddNextStatusEventsToConnectionMutationVariables = Exact<{
 export type AddNextStatusEventsToConnectionMutation = (
   { __typename?: 'Mutation' }
   & { addNextStatusEventsToConnection: (
-    { __typename?: 'SuccessResponseWrap' }
-    & Pick<SuccessResponseWrap, 'error'>
+    { __typename?: 'ProposalNextStatusEventResponseWrap' }
+    & Pick<ProposalNextStatusEventResponseWrap, 'error'>
+    & { nextStatusEvents: Maybe<Array<(
+      { __typename?: 'NextStatusEvent' }
+      & Pick<NextStatusEvent, 'nextStatusEventId' | 'proposalWorkflowConnectionId' | 'nextStatusEvent'>
+    )>> }
   ) }
 );
 
@@ -5780,6 +5790,11 @@ export const UpdateSampleTitleDocument = gql`
 export const AddNextStatusEventsToConnectionDocument = gql`
     mutation addNextStatusEventsToConnection($proposalWorkflowConnectionId: Int!, $nextStatusEvents: [String!]!) {
   addNextStatusEventsToConnection(addNextStatusEventsToConnectionInput: {proposalWorkflowConnectionId: $proposalWorkflowConnectionId, nextStatusEvents: $nextStatusEvents}) {
+    nextStatusEvents {
+      nextStatusEventId
+      proposalWorkflowConnectionId
+      nextStatusEvent
+    }
     error
   }
 }

--- a/src/graphql/settings/addNextStatusEventsToConnection.graphql
+++ b/src/graphql/settings/addNextStatusEventsToConnection.graphql
@@ -8,6 +8,11 @@ mutation addNextStatusEventsToConnection(
       nextStatusEvents: $nextStatusEvents
     }
   ) {
+    nextStatusEvents {
+      nextStatusEventId
+      proposalWorkflowConnectionId
+      nextStatusEvent
+    }
     error
   }
 }

--- a/src/graphql/settings/addNextStatusEventsToConnection.graphql
+++ b/src/graphql/settings/addNextStatusEventsToConnection.graphql
@@ -1,0 +1,13 @@
+mutation addNextStatusEventsToConnection(
+  $proposalWorkflowConnectionId: Int!
+  $nextStatusEvents: [String!]!
+) {
+  addNextStatusEventsToConnection(
+    addNextStatusEventsToConnectionInput: {
+      proposalWorkflowConnectionId: $proposalWorkflowConnectionId
+      nextStatusEvents: $nextStatusEvents
+    }
+  ) {
+    error
+  }
+}

--- a/src/graphql/settings/addProposalWorkflowStatus.graphql
+++ b/src/graphql/settings/addProposalWorkflowStatus.graphql
@@ -6,7 +6,6 @@ mutation addProposalWorkflowStatus(
   $proposalStatusId: Int!
   $nextProposalStatusId: Int
   $prevProposalStatusId: Int
-  $nextStatusEventType: String!
 ) {
   addProposalWorkflowStatus(
     newProposalWorkflowStatusInput: {
@@ -17,7 +16,6 @@ mutation addProposalWorkflowStatus(
       proposalStatusId: $proposalStatusId
       nextProposalStatusId: $nextProposalStatusId
       prevProposalStatusId: $prevProposalStatusId
-      nextStatusEventType: $nextStatusEventType
     }
   ) {
     error

--- a/src/graphql/settings/addProposalWorkflowStatus.graphql
+++ b/src/graphql/settings/addProposalWorkflowStatus.graphql
@@ -18,6 +18,9 @@ mutation addProposalWorkflowStatus(
       prevProposalStatusId: $prevProposalStatusId
     }
   ) {
+    proposalWorkflowConnection {
+      id
+    }
     error
   }
 }

--- a/src/graphql/settings/createProposalWorkflow.graphql
+++ b/src/graphql/settings/createProposalWorkflow.graphql
@@ -21,7 +21,6 @@ mutation createProposalWorkflow($name: String!, $description: String!) {
           }
           nextProposalStatusId
           prevProposalStatusId
-          nextStatusEventType
           droppableGroupId
         }
       }

--- a/src/graphql/settings/createProposalWorkflow.graphql
+++ b/src/graphql/settings/createProposalWorkflow.graphql
@@ -22,6 +22,11 @@ mutation createProposalWorkflow($name: String!, $description: String!) {
           nextProposalStatusId
           prevProposalStatusId
           droppableGroupId
+          nextStatusEvents {
+            nextStatusEventId
+            proposalWorkflowConnectionId
+            nextStatusEvent
+          }
         }
       }
     }

--- a/src/graphql/settings/getProposalWorkflow.graphql
+++ b/src/graphql/settings/getProposalWorkflow.graphql
@@ -19,6 +19,11 @@ query getProposalWorkflow($id: Int!) {
         nextProposalStatusId
         prevProposalStatusId
         droppableGroupId
+        nextStatusEvents {
+          nextStatusEventId
+          proposalWorkflowConnectionId
+          nextStatusEvent
+        }
       }
     }
   }

--- a/src/graphql/settings/getProposalWorkflow.graphql
+++ b/src/graphql/settings/getProposalWorkflow.graphql
@@ -18,7 +18,6 @@ query getProposalWorkflow($id: Int!) {
         }
         nextProposalStatusId
         prevProposalStatusId
-        nextStatusEventType
         droppableGroupId
       }
     }

--- a/src/graphql/settings/updateProposalWorkflow.graphql
+++ b/src/graphql/settings/updateProposalWorkflow.graphql
@@ -30,6 +30,11 @@ mutation updateProposalWorkflow(
           nextProposalStatusId
           prevProposalStatusId
           droppableGroupId
+          nextStatusEvents {
+            nextStatusEventId
+            proposalWorkflowConnectionId
+            nextStatusEvent
+          }
         }
       }
     }

--- a/src/graphql/settings/updateProposalWorkflow.graphql
+++ b/src/graphql/settings/updateProposalWorkflow.graphql
@@ -29,7 +29,6 @@ mutation updateProposalWorkflow(
           }
           nextProposalStatusId
           prevProposalStatusId
-          nextStatusEventType
           droppableGroupId
         }
       }

--- a/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
+++ b/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
@@ -242,7 +242,7 @@ export function usePersistProposalWorkflowEditorModel() {
                 type: EventType.NEXT_STATUS_EVENTS_ADDED,
                 payload: {
                   workflowConnection,
-                  nextStatusEvents,
+                  nextStatusEvents: result.nextStatusEvents,
                 },
               });
             }

--- a/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
+++ b/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
@@ -196,11 +196,6 @@ export function usePersistProposalWorkflowEditorModel() {
             droppableGroupId,
           } = action.payload;
 
-          dispatch({
-            type: EventType.WORKFLOW_STATUS_ADDED,
-            payload: action.payload,
-          });
-
           return executeAndMonitorCall(async () => {
             const result = await insertNewStatusInProposalWorkflow(
               proposalWorkflowId,
@@ -211,6 +206,14 @@ export function usePersistProposalWorkflowEditorModel() {
               nextProposalStatusId,
               prevProposalStatusId
             );
+
+            dispatch({
+              type: EventType.WORKFLOW_STATUS_ADDED,
+              payload: {
+                ...action.payload,
+                id: result.proposalWorkflowConnection?.id,
+              },
+            });
 
             if (result.error) {
               dispatch({
@@ -225,14 +228,24 @@ export function usePersistProposalWorkflowEditorModel() {
           });
         }
 
-        case EventType.ADD_NEXT_STATUS_EVENTS: {
-          const { workflowConnectionId, nextStatusEvents } = action.payload;
+        case EventType.ADD_NEXT_STATUS_EVENTS_REQUESTED: {
+          const { workflowConnection, nextStatusEvents } = action.payload;
 
           return executeAndMonitorCall(async () => {
             const result = await addNextStatusEventsToConnection(
-              workflowConnectionId,
+              workflowConnection.id,
               nextStatusEvents
             );
+
+            if (!result.error) {
+              dispatch({
+                type: EventType.NEXT_STATUS_EVENTS_ADDED,
+                payload: {
+                  workflowConnection,
+                  nextStatusEvents,
+                },
+              });
+            }
 
             return result;
           });

--- a/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
+++ b/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
@@ -90,6 +90,18 @@ export function usePersistProposalWorkflowEditorModel() {
         .then(data => data.deleteProposalWorkflowStatus);
     };
 
+    const addNextStatusEventsToConnection = async (
+      proposalWorkflowConnectionId: number,
+      nextStatusEvents: string[]
+    ) => {
+      return api('Next status events added successfully!')
+        .addNextStatusEventsToConnection({
+          proposalWorkflowConnectionId,
+          nextStatusEvents,
+        })
+        .then(data => data.addNextStatusEventsToConnection);
+    };
+
     return (next: Function) => (action: Event) => {
       next(action);
       const state = getState();
@@ -208,6 +220,19 @@ export function usePersistProposalWorkflowEditorModel() {
                 },
               });
             }
+
+            return result;
+          });
+        }
+
+        case EventType.ADD_NEXT_STATUS_EVENTS: {
+          const { workflowConnectionId, nextStatusEvents } = action.payload;
+
+          return executeAndMonitorCall(async () => {
+            const result = await addNextStatusEventsToConnection(
+              workflowConnectionId,
+              nextStatusEvents
+            );
 
             return result;
           });

--- a/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
+++ b/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
@@ -49,8 +49,7 @@ export function usePersistProposalWorkflowEditorModel() {
       parentDroppableGroupId: string,
       proposalStatusId: number,
       nextProposalStatusId: number,
-      prevProposalStatusId: number,
-      nextStatusEventType: string
+      prevProposalStatusId: number
     ) => {
       return api('Workflow status added successfully')
         .addProposalWorkflowStatus({
@@ -61,7 +60,6 @@ export function usePersistProposalWorkflowEditorModel() {
           proposalStatusId,
           nextProposalStatusId,
           prevProposalStatusId,
-          nextStatusEventType,
         })
         .then(data => data.addProposalWorkflowStatus);
     };
@@ -185,8 +183,6 @@ export function usePersistProposalWorkflowEditorModel() {
             parentDroppableGroupId,
             droppableGroupId,
           } = action.payload;
-          // TODO: We should be able to define this event in the UI maybe. This is about what kind of event triggers proposal status to move forward in the workflow.
-          const nextStatusEventType = 'DEFAULT_EVENT';
 
           dispatch({
             type: EventType.WORKFLOW_STATUS_ADDED,
@@ -201,8 +197,7 @@ export function usePersistProposalWorkflowEditorModel() {
               parentDroppableGroupId,
               proposalStatusId,
               nextProposalStatusId,
-              prevProposalStatusId,
-              nextStatusEventType
+              prevProposalStatusId
             );
 
             if (result.error) {


### PR DESCRIPTION
## Description

This pull request resolves the task: Ability to add multiple events that are triggering the change to the next status on a workflow connection.

## Motivation

Previously, we were not able to add any event that triggers the next status change in the UI and it was hardcoded on some `DEFAULT_EVENT`. Now you can add multiple events and they will be combined with the `AND` operator later when we check for status change in the `WorkflowEngine`.

## Fixes:

* Task: Ability to add multiple events that are triggering the change to the next status on a workflow connection.

## Changes:

Frontend adjustments for task resolution
