### PR TITLE
Fix React redirects in IIS

### DIFF
--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,3 +1,4 @@
+#escape=`
 ARG WINDOWS_VERSION
 
 # Stage 0, "build-stage", based on Node.js, to build and compile the frontend
@@ -11,12 +12,18 @@ RUN npm install --only=production --silent
 
 COPY ./ /app/
 
-RUN npm run build
+RUN npm run build; `
+    # Copy the IIS config to the output directory
+    Copy-Item iis.conf build\web.config
 
 
 FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-${WINDOWS_VERSION}
 
-RUN powershell -NoProfile -Command Remove-Item -Recurse C:\inetpub\wwwroot\*
+RUN powershell -NoProfile -Command Remove-Item -Recurse C:\inetpub\wwwroot\*; `
+    # IIS needs the URLRewrite module to handle React redirects
+    Invoke-WebRequest -UseBasicParsing 'https://download.microsoft.com/download/1/2/8/128E2E22-C1B9-44A4-BE2A-5859ED1D4592/rewrite_amd64_en-US.msi' -Outfile 'urlRewrite.msi'; `
+    Start-Process msiexec.exe -ArgumentList @('/i', 'urlRewrite.msi', '/qn') -NoNewWindow -Wait; `
+    Remove-Item 'urlRewrite.msi'
 
 WORKDIR /inetpub/wwwroot
 

--- a/iis.conf
+++ b/iis.conf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <rule name="ReactRouter Routes" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="/" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
## Description
IIS needs the URLRewrite module to fully handle React redirects. The Dockerfile has been updated to install URLRewrite and a basic config has been added to let React Redirect handle all paths.

## Motivation
Users should be able to directly visit URLs other than the main page.

## Fixes:
- Closes #53

## Changes:
* Windows Dockerfile