### PR TITLE
Swap 495 as a user i should only see the public status of my proposal

### DIFF
--- a/cypress/integration/settings.ts
+++ b/cypress/integration/settings.ts
@@ -350,7 +350,7 @@ context('Settings tests', () => {
 
       cy.get('.MuiTable-root tbody tr')
         .first()
-        .then(element => expect(element.text()).to.contain('DRAFT'));
+        .then(element => expect(element.text()).to.contain('draft'));
 
       cy.get('.MuiTable-root tbody tr')
         .first()
@@ -369,9 +369,7 @@ context('Settings tests', () => {
 
       cy.get('.MuiTable-root tbody tr')
         .first()
-        .then(element =>
-          expect(element.text()).to.contain('FEASIBILITY_REVIEW')
-        );
+        .then(element => expect(element.text()).to.contain('submitted'));
     });
 
     it('User Officer should be able to split workflow into two or more paths', () => {

--- a/cypress/integration/templates.ts
+++ b/cypress/integration/templates.ts
@@ -331,7 +331,7 @@ context('Template tests', () => {
 
     cy.contains('Dashboard').click();
     cy.contains(title);
-    cy.contains('Submitted');
+    cy.contains('submitted');
   });
 
   it('Officer can save proposal column selection', () => {

--- a/src/components/proposal/ProposalTable.tsx
+++ b/src/components/proposal/ProposalTable.tsx
@@ -46,15 +46,7 @@ const ProposalTable: React.FC<ProposalTableProps> = ({
   const columns = [
     { title: 'Proposal ID', field: 'shortCode' },
     { title: 'Title', field: 'title' },
-    {
-      title: 'Submitted',
-      render: (rowData: PartialProposalsDataType) =>
-        rowData.submitted ? 'Yes' : 'No',
-    },
-    {
-      title: 'Status',
-      field: 'status',
-    },
+    { title: 'Status', field: 'publicStatus' },
     { title: 'Created', field: 'created' },
   ];
 

--- a/src/components/proposal/ProposalTableUser.tsx
+++ b/src/components/proposal/ProposalTableUser.tsx
@@ -1,7 +1,11 @@
 import { getTranslation, ResourceId } from '@esss-swap/duo-localisation';
 import React, { useCallback, useState } from 'react';
 
-import { ProposalEndStatus, ProposalStatus } from 'generated/sdk';
+import {
+  ProposalEndStatus,
+  ProposalPublicStatus,
+  ProposalStatus,
+} from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 import { timeAgo } from 'utils/Time';
 
@@ -11,6 +15,7 @@ export type PartialProposalsDataType = {
   id: number;
   title: string;
   status: string;
+  publicStatus: ProposalPublicStatus;
   finalStatus?: string;
   notified?: boolean;
   submitted: boolean;
@@ -61,6 +66,7 @@ const ProposalTableUser: React.FC = () => {
                 id: proposal.id,
                 title: proposal.title,
                 status: getProposalStatus(proposal),
+                publicStatus: proposal.publicStatus,
                 submitted: proposal.submitted,
                 shortCode: proposal.shortCode,
                 created: timeAgo(proposal.created),

--- a/src/components/review/ProposalQuestionaryReview.tsx
+++ b/src/components/review/ProposalQuestionaryReview.tsx
@@ -65,7 +65,7 @@ export default function ProposalQuestionaryReview(
       <Typography variant="h6" className={classes.heading} gutterBottom>
         Questionary
       </Typography>
-      <QuestionaryDetails questionaryId={questionary.questionaryId!} />
+      <QuestionaryDetails questionaryId={questionary.questionaryId} />
     </Fragment>
   );
 }

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -1064,6 +1064,7 @@ export type Proposal = {
   users: Array<BasicUserDetails>;
   proposer: BasicUserDetails;
   status: ProposalStatus;
+  publicStatus: ProposalPublicStatus;
   reviews: Maybe<Array<Review>>;
   technicalReview: Maybe<TechnicalReview>;
   instrument: Maybe<Instrument>;
@@ -1084,6 +1085,14 @@ export enum ProposalEndStatus {
   ACCEPTED = 'ACCEPTED',
   RESERVED = 'RESERVED',
   REJECTED = 'REJECTED'
+}
+
+export enum ProposalPublicStatus {
+  DRAFT = 'draft',
+  SUBMITTED = 'submitted',
+  ACCEPTED = 'accepted',
+  REJECTED = 'rejected',
+  UNKNOWN = 'unknown'
 }
 
 export type ProposalResponseWrap = {
@@ -2727,7 +2736,7 @@ export type CoreTechnicalReviewFragment = (
 
 export type ProposalFragment = (
   { __typename?: 'Proposal' }
-  & Pick<Proposal, 'id' | 'title' | 'abstract' | 'statusId' | 'shortCode' | 'rankOrder' | 'finalStatus' | 'commentForUser' | 'commentForManagement' | 'created' | 'updated' | 'callId' | 'questionaryId' | 'notified' | 'submitted'>
+  & Pick<Proposal, 'id' | 'title' | 'abstract' | 'statusId' | 'publicStatus' | 'shortCode' | 'rankOrder' | 'finalStatus' | 'commentForUser' | 'commentForManagement' | 'created' | 'updated' | 'callId' | 'questionaryId' | 'notified' | 'submitted'>
   & { status: (
     { __typename?: 'ProposalStatus' }
     & Pick<ProposalStatus, 'id' | 'name' | 'description'>
@@ -4317,7 +4326,7 @@ export type GetUserProposalsQuery = (
     { __typename?: 'User' }
     & { proposals: Array<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'shortCode' | 'title' | 'statusId' | 'created' | 'finalStatus' | 'notified' | 'submitted'>
+      & Pick<Proposal, 'id' | 'shortCode' | 'title' | 'publicStatus' | 'statusId' | 'created' | 'finalStatus' | 'notified' | 'submitted'>
       & { status: (
         { __typename?: 'ProposalStatus' }
         & Pick<ProposalStatus, 'id' | 'name' | 'description'>
@@ -4580,6 +4589,7 @@ export const ProposalFragmentDoc = gql`
     name
     description
   }
+  publicStatus
   shortCode
   rankOrder
   finalStatus
@@ -6344,6 +6354,7 @@ export const GetUserProposalsDocument = gql`
         name
         description
       }
+      publicStatus
       statusId
       created
       finalStatus

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -1471,7 +1471,7 @@ export type Question = {
 
 export type Questionary = {
   __typename?: 'Questionary';
-  questionaryId: Maybe<Scalars['Int']>;
+  questionaryId: Scalars['Int'];
   templateId: Scalars['Int'];
   created: Scalars['DateTime'];
   steps: Array<QuestionaryStep>;

--- a/src/graphql/proposal/fragment.proposal.graphql
+++ b/src/graphql/proposal/fragment.proposal.graphql
@@ -8,6 +8,7 @@ fragment proposal on Proposal {
     name
     description
   }
+  publicStatus
   shortCode
   rankOrder
   finalStatus

--- a/src/graphql/user/getUserProposals.graphql
+++ b/src/graphql/user/getUserProposals.graphql
@@ -9,6 +9,7 @@ query getUserProposals {
         name
         description
       }
+      publicStatus
       statusId
       created
       finalStatus


### PR DESCRIPTION
## Description

User should only be able to see the public status of the proposal;

## Motivation and Context

We do not want to show user in which stage the proposal is in, because that is irrelevant and confusing for the user.
User only needs to see if the proposal is in the draft, submitted, accepted,  rejected or reserved

## How Has This Been Tested

e2e testing

## Fixes

https://jira.esss.lu.se/browse/SWAP-495
As a user I should only see if my proposal is in the draft, submitted, rejected, Reserve or accepted
- Remove column submitted,
- In status show DRAFT, SUBMITTED and (ACCEPTED/REJECTED)
- All other statuses between SUBMITTED and ACCEPTED/REJECTED should be simply displayed as SUBMITTED
- Fix that status is always shown as DRAFT


## Changes

Updating ProposalTable to show public status instead of status


## Tests included/Docs Updated?
Relevant tests for changes are done in the backend.

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
