### PR TITLE
improve ui of next status events selection and some call modifications

### DIFF
--- a/cypress/integration/settings.ts
+++ b/cypress/integration/settings.ts
@@ -253,11 +253,9 @@ context('Settings tests', () => {
 
       cy.get('[data-cy="next-status-events-modal"]').should('exist');
 
-      cy.get('[data-cy="next-status-events"]').click();
-
       cy.contains('PROPOSAL_SUBMITTED').click();
 
-      cy.get('[data-cy="submit"]').click({ force: true });
+      cy.get('[data-cy="submit"]').click();
 
       cy.notification({
         variant: 'success',
@@ -302,11 +300,9 @@ context('Settings tests', () => {
 
       cy.get('[data-cy="next-status-events-modal"]').should('exist');
 
-      cy.get('[data-cy="next-status-events"]').click();
-
       cy.contains('PROPOSAL_SUBMITTED').click();
 
-      cy.get('[data-cy="submit"]').click({ force: true });
+      cy.get('[data-cy="submit"]').click();
 
       cy.notification({
         variant: 'success',

--- a/src/components/call/CallNotificationAndCycleInfo.tsx
+++ b/src/components/call/CallNotificationAndCycleInfo.tsx
@@ -10,6 +10,20 @@ const CallCycleInfo: React.FC = () => (
   <>
     <MuiPickersUtilsProvider utils={DateFnsUtils}>
       <Field
+        name="startNotify"
+        label="Start of notification period"
+        component={FormikUICustomDatePicker}
+        margin="normal"
+        fullWidth
+      />
+      <Field
+        name="endNotify"
+        label="End of notification period"
+        component={FormikUICustomDatePicker}
+        margin="normal"
+        fullWidth
+      />
+      <Field
         name="startCycle"
         label="Start of cycle"
         component={FormikUICustomDatePicker}

--- a/src/components/call/CallReviewsInfo.tsx
+++ b/src/components/call/CallReviewsInfo.tsx
@@ -25,15 +25,15 @@ const CallReviewAndNotification: React.FC = () => (
         fullWidth
       />
       <Field
-        name="startNotify"
-        label="Start of notification period"
+        name="startSEPReview"
+        label="Start of SEP review"
         component={FormikUICustomDatePicker}
         margin="normal"
         fullWidth
       />
       <Field
-        name="endNotify"
-        label="End of notification period"
+        name="endSEPReview"
+        label="End of SEP review"
         component={FormikUICustomDatePicker}
         margin="normal"
         fullWidth

--- a/src/components/call/CreateUpdateCall.tsx
+++ b/src/components/call/CreateUpdateCall.tsx
@@ -20,9 +20,9 @@ import UOLoader from 'components/common/UOLoader';
 import { Call } from 'generated/sdk';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 
-import CallCycleInfo from './CallCycleInfo';
 import CallGeneralInfo from './CallGeneralInfo';
-import CallReviewAndNotification from './CallReviewAndNotification';
+import CallNotificationAndCycleInfo from './CallNotificationAndCycleInfo';
+import CallReviewsInfo from './CallReviewsInfo';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -66,16 +66,16 @@ const CreateUpdateCall: React.FC<CreateUpdateCallProps> = ({ call, close }) => {
   const currentDayEnd = new Date();
   currentDayEnd.setHours(23, 59, 59, 999);
 
-  const steps = ['General info', 'Review and notification', 'Cycle info'];
+  const steps = ['General', 'Reviews', 'Notification and cycle'];
 
   const getStepContent = (step: number) => {
     switch (step) {
       case 0:
         return <CallGeneralInfo />;
       case 1:
-        return <CallReviewAndNotification />;
+        return <CallReviewsInfo />;
       case 2:
-        return <CallCycleInfo />;
+        return <CallNotificationAndCycleInfo />;
       default:
         return 'Unknown step';
     }
@@ -107,6 +107,8 @@ const CreateUpdateCall: React.FC<CreateUpdateCallProps> = ({ call, close }) => {
         endCall: currentDayEnd,
         startReview: currentDayStart,
         endReview: currentDayEnd,
+        startSEPReview: null,
+        endSEPReview: null,
         startNotify: currentDayStart,
         endNotify: currentDayEnd,
         startCycle: currentDayStart,

--- a/src/components/review/ProposalReviewUserOfficer.tsx
+++ b/src/components/review/ProposalReviewUserOfficer.tsx
@@ -60,8 +60,6 @@ const ProposalReview: React.FC<ProposalReviewProps> = ({ match }) => {
     tabNames.push('Logs');
   }
 
-  console.log(proposal);
-
   return (
     <Container maxWidth="lg">
       <SimpleTabs tabNames={tabNames}>

--- a/src/components/settings/proposalWorkflow/ProposalWorkflowConnectionsEditor.tsx
+++ b/src/components/settings/proposalWorkflow/ProposalWorkflowConnectionsEditor.tsx
@@ -21,6 +21,7 @@ import {
   ProposalWorkflowConnection,
   ProposalWorkflowConnectionGroup,
 } from 'generated/sdk';
+import { Event as ProposalEvent } from 'generated/sdk';
 
 import AddNewWorkflowConnectionsRow from './AddNewWorkflowConnectionsRow';
 import AddNextStatusEventsToConnection from './AddNextStatusEventsToConnection';
@@ -328,6 +329,8 @@ const ProposalWorkflowConnectionsEditor: React.FC<ProposalWorkflowConnectionsEdi
         </DialogContent>
       </Dialog>
       <Dialog
+        maxWidth="md"
+        fullWidth={true}
         aria-labelledby="simple-modal-title"
         aria-describedby="simple-modal-description"
         open={!!workflowConnection}
@@ -340,7 +343,7 @@ const ProposalWorkflowConnectionsEditor: React.FC<ProposalWorkflowConnectionsEdi
             nextStatusEvents={
               workflowConnection?.nextStatusEvents?.map(
                 nextStatusEvent => nextStatusEvent.nextStatusEvent
-              ) as string[]
+              ) as ProposalEvent[]
             }
             addNextStatusEventsToConnection={(nextStatusEvents: string[]) =>
               dispatch({

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -137,6 +137,8 @@ export type Call = {
   endCall: Scalars['DateTime'];
   startReview: Scalars['DateTime'];
   endReview: Scalars['DateTime'];
+  startSEPReview: Maybe<Scalars['DateTime']>;
+  endSEPReview: Maybe<Scalars['DateTime']>;
   startNotify: Scalars['DateTime'];
   endNotify: Scalars['DateTime'];
   startCycle: Scalars['DateTime'];
@@ -158,6 +160,9 @@ export type CallResponseWrap = {
 export type CallsFilter = {
   templateIds?: Maybe<Array<Scalars['Int']>>;
   isActive?: Maybe<Scalars['Boolean']>;
+  isEnded?: Maybe<Scalars['Boolean']>;
+  isReviewEnded?: Maybe<Scalars['Boolean']>;
+  isSEPReviewEnded?: Maybe<Scalars['Boolean']>;
 };
 
 export type CreateCallInput = {
@@ -166,6 +171,8 @@ export type CreateCallInput = {
   endCall: Scalars['DateTime'];
   startReview: Scalars['DateTime'];
   endReview: Scalars['DateTime'];
+  startSEPReview?: Maybe<Scalars['DateTime']>;
+  endSEPReview?: Maybe<Scalars['DateTime']>;
   startNotify: Scalars['DateTime'];
   endNotify: Scalars['DateTime'];
   startCycle: Scalars['DateTime'];
@@ -248,6 +255,7 @@ export enum Event {
   PROPOSAL_CREATED = 'PROPOSAL_CREATED',
   PROPOSAL_UPDATED = 'PROPOSAL_UPDATED',
   PROPOSAL_SUBMITTED = 'PROPOSAL_SUBMITTED',
+  PROPOSAL_FEASIBLE = 'PROPOSAL_FEASIBLE',
   PROPOSAL_SEP_SELECTED = 'PROPOSAL_SEP_SELECTED',
   PROPOSAL_INSTRUMENT_SELECTED = 'PROPOSAL_INSTRUMENT_SELECTED',
   PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED = 'PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED',
@@ -259,6 +267,8 @@ export enum Event {
   PROPOSAL_ACCEPTED = 'PROPOSAL_ACCEPTED',
   PROPOSAL_REJECTED = 'PROPOSAL_REJECTED',
   CALL_ENDED = 'CALL_ENDED',
+  CALL_REVIEW_ENDED = 'CALL_REVIEW_ENDED',
+  CALL_SEP_REVIEW_ENDED = 'CALL_SEP_REVIEW_ENDED',
   USER_CREATED = 'USER_CREATED',
   USER_UPDATED = 'USER_UPDATED',
   USER_ROLE_UPDATED = 'USER_ROLE_UPDATED',
@@ -1845,6 +1855,8 @@ export type UpdateCallInput = {
   endCall: Scalars['DateTime'];
   startReview: Scalars['DateTime'];
   endReview: Scalars['DateTime'];
+  startSEPReview?: Maybe<Scalars['DateTime']>;
+  endSEPReview?: Maybe<Scalars['DateTime']>;
   startNotify: Scalars['DateTime'];
   endNotify: Scalars['DateTime'];
   startCycle: Scalars['DateTime'];
@@ -1852,6 +1864,9 @@ export type UpdateCallInput = {
   cycleComment: Scalars['String'];
   surveyComment: Scalars['String'];
   proposalWorkflowId?: Maybe<Scalars['Int']>;
+  callEnded?: Maybe<Scalars['Int']>;
+  callReviewEnded?: Maybe<Scalars['Int']>;
+  callSEPReviewEnded?: Maybe<Scalars['Int']>;
   templateId?: Maybe<Scalars['Int']>;
 };
 
@@ -2369,6 +2384,8 @@ export type CreateCallMutationVariables = Exact<{
   endCall: Scalars['DateTime'];
   startReview: Scalars['DateTime'];
   endReview: Scalars['DateTime'];
+  startSEPReview?: Maybe<Scalars['DateTime']>;
+  endSEPReview?: Maybe<Scalars['DateTime']>;
   startNotify: Scalars['DateTime'];
   endNotify: Scalars['DateTime'];
   startCycle: Scalars['DateTime'];
@@ -2394,7 +2411,7 @@ export type CreateCallMutation = (
 
 export type CallFragment = (
   { __typename?: 'Call' }
-  & Pick<Call, 'id' | 'shortCode' | 'startCall' | 'endCall' | 'startReview' | 'endReview' | 'startNotify' | 'endNotify' | 'startCycle' | 'endCycle' | 'cycleComment' | 'surveyComment' | 'proposalWorkflowId' | 'templateId'>
+  & Pick<Call, 'id' | 'shortCode' | 'startCall' | 'endCall' | 'startReview' | 'endReview' | 'startSEPReview' | 'endSEPReview' | 'startNotify' | 'endNotify' | 'startCycle' | 'endCycle' | 'cycleComment' | 'surveyComment' | 'proposalWorkflowId' | 'templateId'>
   & { instruments: Array<(
     { __typename?: 'InstrumentWithAvailabilityTime' }
     & Pick<InstrumentWithAvailabilityTime, 'id' | 'name' | 'shortCode' | 'description' | 'availabilityTime' | 'submitted'>
@@ -2459,6 +2476,8 @@ export type UpdateCallMutationVariables = Exact<{
   endCall: Scalars['DateTime'];
   startReview: Scalars['DateTime'];
   endReview: Scalars['DateTime'];
+  startSEPReview?: Maybe<Scalars['DateTime']>;
+  endSEPReview?: Maybe<Scalars['DateTime']>;
   startNotify: Scalars['DateTime'];
   endNotify: Scalars['DateTime'];
   startCycle: Scalars['DateTime'];
@@ -2477,14 +2496,7 @@ export type UpdateCallMutation = (
     & Pick<CallResponseWrap, 'error'>
     & { call: Maybe<(
       { __typename?: 'Call' }
-      & Pick<Call, 'id' | 'shortCode' | 'startCall' | 'endCall' | 'startReview' | 'endReview' | 'startNotify' | 'endNotify' | 'startCycle' | 'endCycle' | 'cycleComment' | 'surveyComment' | 'proposalWorkflowId' | 'templateId'>
-      & { instruments: Array<(
-        { __typename?: 'InstrumentWithAvailabilityTime' }
-        & Pick<InstrumentWithAvailabilityTime, 'id' | 'name' | 'shortCode' | 'description' | 'availabilityTime'>
-      )>, proposalWorkflow: Maybe<(
-        { __typename?: 'ProposalWorkflow' }
-        & Pick<ProposalWorkflow, 'id' | 'name' | 'description'>
-      )> }
+      & CallFragment
     )> }
   ) }
 );
@@ -4592,6 +4604,8 @@ export const CallFragmentDoc = gql`
   endCall
   startReview
   endReview
+  startSEPReview
+  endSEPReview
   startNotify
   endNotify
   startCycle
@@ -5201,8 +5215,8 @@ export const AssignInstrumentsToCallDocument = gql`
 }
     `;
 export const CreateCallDocument = gql`
-    mutation createCall($shortCode: String!, $startCall: DateTime!, $endCall: DateTime!, $startReview: DateTime!, $endReview: DateTime!, $startNotify: DateTime!, $endNotify: DateTime!, $startCycle: DateTime!, $endCycle: DateTime!, $cycleComment: String!, $surveyComment: String!, $proposalWorkflowId: Int, $templateId: Int) {
-  createCall(createCallInput: {shortCode: $shortCode, startCall: $startCall, endCall: $endCall, startReview: $startReview, endReview: $endReview, startNotify: $startNotify, endNotify: $endNotify, startCycle: $startCycle, endCycle: $endCycle, cycleComment: $cycleComment, surveyComment: $surveyComment, proposalWorkflowId: $proposalWorkflowId, templateId: $templateId}) {
+    mutation createCall($shortCode: String!, $startCall: DateTime!, $endCall: DateTime!, $startReview: DateTime!, $endReview: DateTime!, $startSEPReview: DateTime, $endSEPReview: DateTime, $startNotify: DateTime!, $endNotify: DateTime!, $startCycle: DateTime!, $endCycle: DateTime!, $cycleComment: String!, $surveyComment: String!, $proposalWorkflowId: Int, $templateId: Int) {
+  createCall(createCallInput: {shortCode: $shortCode, startCall: $startCall, endCall: $endCall, startReview: $startReview, endReview: $endReview, startSEPReview: $startSEPReview, endSEPReview: $endSEPReview, startNotify: $startNotify, endNotify: $endNotify, startCycle: $startCycle, endCycle: $endCycle, cycleComment: $cycleComment, surveyComment: $surveyComment, proposalWorkflowId: $proposalWorkflowId, templateId: $templateId}) {
     error
     call {
       ...call
@@ -5235,40 +5249,15 @@ export const RemoveAssignedInstrumentFromCallDocument = gql`
 }
     `;
 export const UpdateCallDocument = gql`
-    mutation updateCall($id: Int!, $shortCode: String!, $startCall: DateTime!, $endCall: DateTime!, $startReview: DateTime!, $endReview: DateTime!, $startNotify: DateTime!, $endNotify: DateTime!, $startCycle: DateTime!, $endCycle: DateTime!, $cycleComment: String!, $surveyComment: String!, $proposalWorkflowId: Int, $templateId: Int) {
-  updateCall(updateCallInput: {id: $id, shortCode: $shortCode, startCall: $startCall, endCall: $endCall, startReview: $startReview, endReview: $endReview, startNotify: $startNotify, endNotify: $endNotify, startCycle: $startCycle, endCycle: $endCycle, cycleComment: $cycleComment, surveyComment: $surveyComment, proposalWorkflowId: $proposalWorkflowId, templateId: $templateId}) {
+    mutation updateCall($id: Int!, $shortCode: String!, $startCall: DateTime!, $endCall: DateTime!, $startReview: DateTime!, $endReview: DateTime!, $startSEPReview: DateTime, $endSEPReview: DateTime, $startNotify: DateTime!, $endNotify: DateTime!, $startCycle: DateTime!, $endCycle: DateTime!, $cycleComment: String!, $surveyComment: String!, $proposalWorkflowId: Int, $templateId: Int) {
+  updateCall(updateCallInput: {id: $id, shortCode: $shortCode, startCall: $startCall, endCall: $endCall, startReview: $startReview, endReview: $endReview, startSEPReview: $startSEPReview, endSEPReview: $endSEPReview, startNotify: $startNotify, endNotify: $endNotify, startCycle: $startCycle, endCycle: $endCycle, cycleComment: $cycleComment, surveyComment: $surveyComment, proposalWorkflowId: $proposalWorkflowId, templateId: $templateId}) {
     error
     call {
-      id
-      shortCode
-      startCall
-      endCall
-      startReview
-      endReview
-      startNotify
-      endNotify
-      startCycle
-      endCycle
-      cycleComment
-      surveyComment
-      proposalWorkflowId
-      templateId
-      instruments {
-        id
-        name
-        shortCode
-        description
-        availabilityTime
-      }
-      proposalWorkflow {
-        id
-        name
-        description
-      }
+      ...call
     }
   }
 }
-    `;
+    ${CallFragmentDoc}`;
 export const GetEventLogsDocument = gql`
     query getEventLogs($eventType: String!, $changedObjectId: String!) {
   eventLogs(eventType: $eventType, changedObjectId: $changedObjectId) {

--- a/src/graphql/call/createCall.graphql
+++ b/src/graphql/call/createCall.graphql
@@ -4,6 +4,8 @@ mutation createCall(
   $endCall: DateTime!
   $startReview: DateTime!
   $endReview: DateTime!
+  $startSEPReview: DateTime
+  $endSEPReview: DateTime
   $startNotify: DateTime!
   $endNotify: DateTime!
   $startCycle: DateTime!
@@ -20,6 +22,8 @@ mutation createCall(
       endCall: $endCall
       startReview: $startReview
       endReview: $endReview
+      startSEPReview: $startSEPReview
+      endSEPReview: $endSEPReview
       startNotify: $startNotify
       endNotify: $endNotify
       startCycle: $startCycle

--- a/src/graphql/call/fragment.call.graphql
+++ b/src/graphql/call/fragment.call.graphql
@@ -5,6 +5,8 @@ fragment call on Call {
   endCall
   startReview
   endReview
+  startSEPReview
+  endSEPReview
   startNotify
   endNotify
   startCycle

--- a/src/graphql/call/updateCall.graphql
+++ b/src/graphql/call/updateCall.graphql
@@ -5,6 +5,8 @@ mutation updateCall(
   $endCall: DateTime!
   $startReview: DateTime!
   $endReview: DateTime!
+  $startSEPReview: DateTime
+  $endSEPReview: DateTime
   $startNotify: DateTime!
   $endNotify: DateTime!
   $startCycle: DateTime!
@@ -22,6 +24,8 @@ mutation updateCall(
       endCall: $endCall
       startReview: $startReview
       endReview: $endReview
+      startSEPReview: $startSEPReview
+      endSEPReview: $endSEPReview
       startNotify: $startNotify
       endNotify: $endNotify
       startCycle: $startCycle
@@ -34,32 +38,7 @@ mutation updateCall(
   ) {
     error
     call {
-      id
-      shortCode
-      startCall
-      endCall
-      startReview
-      endReview
-      startNotify
-      endNotify
-      startCycle
-      endCycle
-      cycleComment
-      surveyComment
-      proposalWorkflowId
-      templateId
-      instruments {
-        id
-        name
-        shortCode
-        description
-        availabilityTime
-      }
-      proposalWorkflow {
-        id
-        name
-        description
-      }
+      ...call
     }
   }
 }


### PR DESCRIPTION
## Description

UI improvement of next status event rules selection in the proposal workflow and adding some missing call dates for SEP review.

## Motivation and Context

It was really hard to select next status event rules with the previous solution and for being able to close SEP review we need an ending date.

## How Has This Been Tested

It has e2e tests.

## Fixes

https://jira.esss.lu.se/browse/SWAP-1132

## Changes

UI changes of the modal where you select the next event status rules and addition of new fields on call creation/update.


## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
