### PR TITLE
SWAP-1205 Fix scheduler triggered login

### DIFF
--- a/src/components/user/SignIn.tsx
+++ b/src/components/user/SignIn.tsx
@@ -78,7 +78,7 @@ export default function SignInSide() {
   const classes = useStyles();
   const [failedLogin, setFailed] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-  const { handleLogin, token } = useContext(UserContext);
+  const { handleLogin, token, currentRole } = useContext(UserContext);
   const unauthorizedApi = useUnauthorizedApi();
   const location = useLocation();
 
@@ -105,7 +105,7 @@ export default function SignInSide() {
     }
   };
 
-  if (token) {
+  if (token && currentRole) {
     const authRedirect = new URLSearchParams(location.search).get(
       'authRedirect'
     );

--- a/src/context/UserContextProvider.tsx
+++ b/src/context/UserContextProvider.tsx
@@ -88,19 +88,14 @@ const reducer = (
       localStorage.token = action.payload;
       localStorage.expToken = decoded.exp;
 
-      if (decoded.roles.length === 1) {
-        localStorage.currentRole = decoded.roles[0].shortCode.toUpperCase();
-      }
+      localStorage.currentRole = decoded.roles[0].shortCode.toUpperCase();
 
       return {
         token: action.payload,
         user: decoded.user,
         expToken: decoded.exp,
         roles: decoded.roles,
-        currentRole:
-          decoded.roles.length === 1
-            ? decoded.roles[0].shortCode.toUpperCase()
-            : null,
+        currentRole: decoded.roles[0].shortCode.toUpperCase(),
       };
     case ActionType.SETTOKEN:
       const newToken = decode(action.payload) as DecodedTokenData;


### PR DESCRIPTION
## Description

This PR fixes an invalid app state which is caused by login triggered by the scheduler.

## Motivation and Context

A login triggered by the scheduler results in an invalid localStorage state which makes the frontend think the user is not logged in, although there is a token in the localStorage.

## How Has This Been Tested

existing e2e not failing

## Fixes

https://jira.esss.lu.se/browse/SWAP-1205

## Changes

- After login, we set the first available role regardless of how many roles a user has, previously it was done in `App.tsx`.
- We also wait for an available role and token before moving on.

## Depends on

No dependencies

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
