### PR TITLE
SWAP-1175 Cloning sample multiple times does not work

### DIFF
--- a/src/components/questionary/formComponents/QuestionaryComponentSampleDeclaration.tsx
+++ b/src/components/questionary/formComponents/QuestionaryComponentSampleDeclaration.tsx
@@ -109,6 +109,7 @@ function QuestionaryComponentSampleDeclaration(props: BasicComponentProps) {
                 const clonedSample = response.cloneSample.sample;
                 if (clonedSample) {
                   const newStateValue = [...stateValue, clonedSample.id];
+                  setStateValue(newStateValue);
                   setRows([...rows, sampleToListRow(clonedSample)]);
                   onComplete(null as any, newStateValue);
                 }


### PR DESCRIPTION
## Description

Bugfix

## Motivation and Context
Cloning sample multiple times does not work
When the user is creating a proposal and a sample is requested to provide then if zie chooses to clone the sample multiple times, then only not all cloned samples will appear. 

## How Has This Been Tested

Manual testing

## Fixes

SWAP-1175


## Depends on

N/A

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
