### PR TITLE
Swap 1159 Bugfix, for selecting a missing dependency answer.

### DIFF
--- a/src/components/common/FormikUICustomDependencySelector.tsx
+++ b/src/components/common/FormikUICustomDependencySelector.tsx
@@ -12,9 +12,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   DataType,
   EvaluatorOperator,
-  Template,
   QuestionTemplateRelation,
   SelectionFromOptionsConfig,
+  Template,
 } from 'generated/sdk';
 import { getAllFields, getFieldById } from 'models/QuestionaryFunctions';
 
@@ -95,7 +95,7 @@ const FormikUICustomDependencySelector = ({
         depField.question.dataType === DataType.SELECTION_FROM_OPTIONS
       ) {
         setAvailableValues(
-          (depField.question.config as SelectionFromOptionsConfig).options.map(
+          (depField.config as SelectionFromOptionsConfig).options.map(
             option => {
               return { value: option, label: option };
             }

--- a/src/components/questionary/questionaryComponents/MultipleChoice/QuestionaryComponentMultipleChoice.tsx
+++ b/src/components/questionary/questionaryComponents/MultipleChoice/QuestionaryComponentMultipleChoice.tsx
@@ -7,7 +7,7 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import TextField from '@material-ui/core/TextField';
 import { getIn } from 'formik';
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { BasicComponentProps } from 'components/proposal/IBasicComponentProps';
 import { SelectionFromOptionsConfig } from 'generated/sdk';
@@ -30,19 +30,19 @@ export function QuestionaryComponentMultipleChoice(props: BasicComponentProps) {
     },
   })();
 
-  const { answer: templateField, touched, errors, onComplete } = props;
+  const { answer, touched, errors, onComplete } = props;
   const {
     question: { proposalQuestionId, question },
     value,
-  } = templateField;
+  } = answer;
   const [stateValue, setStateValue] = useState(value);
   const fieldError = getIn(errors, proposalQuestionId);
   const isError = getIn(touched, proposalQuestionId) && !!fieldError;
-  const config = templateField.config as SelectionFromOptionsConfig;
+  const config = answer.config as SelectionFromOptionsConfig;
 
   useEffect(() => {
-    setStateValue(templateField.value);
-  }, [templateField]);
+    setStateValue(answer.value);
+  }, [answer]);
 
   const handleOnChange = (evt: any, newValue: any) => {
     setStateValue(newValue);


### PR DESCRIPTION
## Description

Bugfix, for selecting a missing dependency answer.
A multiple-choice question can have a set of answers. But when assigning the question to the template officer can override the answers. Then when specifying a dependency on that question, the original (not overridden) answers are shown in the list. 

## Motivation and Context

Show the overridden answers instead.

## How Has This Been Tested

e2e tests
manual tests

## Fixes

SWAP-1159

## Depends on

N/A

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
