### PR TITLE
Bugfix for single select

### DIFF
--- a/src/components/questionary/questionaryComponents/MultipleChoice/QuestionaryComponentMultipleChoice.tsx
+++ b/src/components/questionary/questionaryComponents/MultipleChoice/QuestionaryComponentMultipleChoice.tsx
@@ -12,6 +12,14 @@ import React, { useEffect, useState } from 'react';
 import { BasicComponentProps } from 'components/proposal/IBasicComponentProps';
 import { SelectionFromOptionsConfig } from 'generated/sdk';
 
+const toArray = (input: string | string[]): string[] => {
+  if (typeof input === 'string') {
+    return [input];
+  }
+
+  return input;
+};
+
 export function QuestionaryComponentMultipleChoice(props: BasicComponentProps) {
   const classes = makeStyles({
     horizontalLayout: {
@@ -44,7 +52,8 @@ export function QuestionaryComponentMultipleChoice(props: BasicComponentProps) {
     setStateValue(answer.value);
   }, [answer]);
 
-  const handleOnChange = (evt: any, newValue: any) => {
+  const handleOnChange = (evt: any, value: string | string[]) => {
+    const newValue = toArray(value);
     setStateValue(newValue);
     onComplete(evt, newValue);
   };
@@ -56,7 +65,7 @@ export function QuestionaryComponentMultipleChoice(props: BasicComponentProps) {
           <TextField
             id={proposalQuestionId}
             name={proposalQuestionId}
-            value={stateValue}
+            value={config.isMultipleSelect ? stateValue : stateValue[0]}
             label={question}
             select
             onChange={evt =>
@@ -93,7 +102,7 @@ export function QuestionaryComponentMultipleChoice(props: BasicComponentProps) {
           <RadioGroup
             id={proposalQuestionId}
             name={proposalQuestionId}
-            value={stateValue}
+            value={stateValue[0]}
             onChange={evt =>
               handleOnChange(evt, (evt.target as HTMLInputElement).value)
             }


### PR DESCRIPTION
## Description

This fixes a regression bug introduced when added multiple-choice answers, where it is possible to specify multiple answers to one question. 

The bug was that the dropdown or radio component was not working due to the answer now being saved as an array.

## Motivation and Context

Fixes bug

## How Has This Been Tested

Manual testing
e2e testing

## Fixes

Regression bugfix for SWAP-1141

## Changes

multiple-choice answer should always send and be able to interpret the answer that is an array

## Depends on

N/A

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
