### PR TITLE
SWAP-1172 The checkbox value when selecting a user is not preserved

### DIFF
--- a/cypress/integration/other/peopleTable.ts
+++ b/cypress/integration/other/peopleTable.ts
@@ -1,0 +1,44 @@
+before(() => {
+  cy.resetDB();
+});
+
+describe('PageTable component tests', () => {
+  describe('Preserve selected users', () => {
+    it('should preserve the selected users', () => {
+      cy.login('user');
+
+      cy.contains('New Proposal').click();
+
+      cy.get('[title="Add Co-Proposers"]').click();
+
+      cy.contains('0 user(s) selected');
+
+      cy.get('[data-cy="co-proposers"] tr[index="0"] input').click();
+
+      cy.contains('1 user(s) selected');
+
+      cy.get('[data-cy="co-proposers"] [aria-label="Search"]').type('foo bar');
+
+      cy.contains('No records to display');
+      cy.contains('1 user(s) selected');
+
+      cy.get(
+        '[data-cy="co-proposers"] [aria-label="Search"] ~ * > button'
+      ).click();
+
+      cy.contains('1 user(s) selected');
+      cy.contains('Carlsson');
+
+      cy.get('[data-cy="co-proposers"] tr[index="0"] input:checked');
+
+      cy.get('[data-cy="co-proposers"] [aria-label="Search"]').type('Carlsson');
+
+      cy.contains('1 user(s) selected');
+      cy.contains('Carlsson');
+
+      cy.get('[data-cy="co-proposers"] tr[index="0"] input:checked');
+
+      cy.get('[data-cy="assign-selected-users"]').click();
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR aims to fix an annoying behavior of user selection: if the user selects a user and uses the search bar, although we keep track of the selected users in the background, there is no visual feedback of it on the UI.
With this change, after a search or when the search bar is cleared, the checkbox will stay selected.
It is also shown how many users are selected, even if the user table is empty after a search.
<!--- Describe your changes in detail -->

## How Has This Been Tested

- [x] e2e test added for test a part of the UI
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1172
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- additional visual indicator added for showing the number of the selected users
- mark an already selected row as selected on the UI after a fetch
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
