### PR TITLE
SWAP-1264 Trying to assign or unassign an instrument to the same proposal without "refresh" results in errors

### DIFF
--- a/cypress/integration/instruments.ts
+++ b/cypress/integration/instruments.ts
@@ -120,6 +120,78 @@ context('Instrument tests', () => {
     cy.get('[title="Remove assigned instrument"]').should('exist');
   });
 
+  it('User Officer should be able to assign and unassign instrument to proposal without page refresh', () => {
+    cy.login('officer');
+
+    cy.get('tbody [type="checkbox"]')
+      .first()
+      .check();
+
+    cy.get('[title="Remove assigned instrument"]')
+      .first()
+      .click();
+
+    cy.get('[data-cy="confirm-yes"]').click();
+
+    cy.notification({
+      variant: 'success',
+      text: 'Proposal removed from the instrument successfully!',
+    });
+
+    cy.get("[title='Assign proposals to instrument']")
+      .first()
+      .click();
+
+    cy.get("[id='mui-component-select-selectedInstrumentId']")
+      .first()
+      .click();
+
+    cy.get("[id='menu-selectedInstrumentId'] li")
+      .first()
+      .click();
+
+    cy.contains('Assign to Instrument').click();
+
+    cy.notification({
+      variant: 'success',
+      text: 'Proposal/s assigned to the selected instrument',
+    });
+
+    cy.get('[title="Remove assigned instrument"]').should('exist');
+
+    cy.get('[title="Remove assigned instrument"]')
+      .first()
+      .click();
+
+    cy.get('[data-cy="confirm-yes"]').click();
+
+    cy.notification({
+      variant: 'success',
+      text: 'Proposal removed from the instrument successfully!',
+    });
+
+    cy.get("[title='Assign proposals to instrument']")
+      .first()
+      .click();
+
+    cy.get("[id='mui-component-select-selectedInstrumentId']")
+      .first()
+      .click();
+
+    cy.get("[id='menu-selectedInstrumentId'] li")
+      .first()
+      .click();
+
+    cy.contains('Assign to Instrument').click();
+
+    cy.notification({
+      variant: 'success',
+      text: 'Proposal/s assigned to the selected instrument',
+    });
+
+    cy.get('[title="Remove assigned instrument"]').should('exist');
+  });
+
   it('User Officer should be able to assign scientist to instrument and instrument scientist should be able to see instruments he is assigned to', () => {
     cy.login('officer');
 
@@ -189,7 +261,7 @@ context('Instrument tests', () => {
     cy.get('[title="Show Scientists"]').should('exist');
   });
 
-  it('Instrument scientsit should be able to see proposals assigned to instrument where he is instrument scientist', () => {
+  it('Instrument scientist should be able to see proposals assigned to instrument where he is instrument scientist', () => {
     cy.login('user');
 
     cy.get('[data-cy="profile-page-btn"]').click();

--- a/cypress/integration/instruments.ts
+++ b/cypress/integration/instruments.ts
@@ -123,6 +123,10 @@ context('Instrument tests', () => {
   it('User Officer should be able to assign and unassign instrument to proposal without page refresh', () => {
     cy.login('officer');
 
+    cy.contains('Proposals').click();
+
+    cy.finishedLoading();
+
     cy.get('tbody [type="checkbox"]')
       .first()
       .check();
@@ -138,9 +142,9 @@ context('Instrument tests', () => {
       text: 'Proposal removed from the instrument successfully!',
     });
 
-    cy.get("[title='Assign proposals to instrument']")
+    cy.get('[data-cy="assign-proposals-to-instrument"]')
       .first()
-      .click();
+      .trigger('click');
 
     cy.get("[id='mui-component-select-selectedInstrumentId']")
       .first()
@@ -157,8 +161,6 @@ context('Instrument tests', () => {
       text: 'Proposal/s assigned to the selected instrument',
     });
 
-    cy.get('[title="Remove assigned instrument"]').should('exist');
-
     cy.get('[title="Remove assigned instrument"]')
       .first()
       .click();
@@ -170,9 +172,9 @@ context('Instrument tests', () => {
       text: 'Proposal removed from the instrument successfully!',
     });
 
-    cy.get("[title='Assign proposals to instrument']")
+    cy.get('[data-cy="assign-proposals-to-instrument"]')
       .first()
-      .click();
+      .trigger('click');
 
     cy.get("[id='mui-component-select-selectedInstrumentId']")
       .first()

--- a/cypress/integration/instruments.ts
+++ b/cypress/integration/instruments.ts
@@ -144,7 +144,7 @@ context('Instrument tests', () => {
 
     cy.get('[data-cy="assign-proposals-to-instrument"]')
       .first()
-      .trigger('click');
+      .click();
 
     cy.get("[id='mui-component-select-selectedInstrumentId']")
       .first()
@@ -174,7 +174,7 @@ context('Instrument tests', () => {
 
     cy.get('[data-cy="assign-proposals-to-instrument"]')
       .first()
-      .trigger('click');
+      .click();
 
     cy.get("[id='mui-component-select-selectedInstrumentId']")
       .first()

--- a/src/components/proposal/ProposalTableOfficer.tsx
+++ b/src/components/proposal/ProposalTableOfficer.tsx
@@ -384,7 +384,9 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
   const DeleteIcon = (): JSX.Element => <Delete />;
   const GroupWorkIcon = (): JSX.Element => <GroupWork />;
   const EmailIcon = (): JSX.Element => <Email />;
-  const AddScienceIcon = (): JSX.Element => <ScienceIconAdd />;
+  const AddScienceIcon = (props?: any): JSX.Element => (
+    <ScienceIconAdd {...props} />
+  );
   const ExportIcon = (): JSX.Element => <GridOnIcon />;
 
   const preselectedProposalsData =
@@ -542,7 +544,9 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
             position: 'toolbarOnSelect',
           },
           {
-            icon: AddScienceIcon,
+            icon: AddScienceIcon.bind(null, {
+              'data-cy': 'assign-proposals-to-instrument',
+            }),
             tooltip: 'Assign proposals to instrument',
             onClick: (event, rowData): void => {
               setOpenInstrumentAssignment(true);

--- a/src/components/proposal/ProposalTableOfficer.tsx
+++ b/src/components/proposal/ProposalTableOfficer.tsx
@@ -92,32 +92,35 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
 
   const removeProposalFromInstrument = async () => {
     if (
-      proposalAndInstrumentId.instrumentId &&
-      proposalAndInstrumentId.proposalId
+      !proposalAndInstrumentId.instrumentId ||
+      !proposalAndInstrumentId.proposalId
     ) {
-      const result = await api(
-        'Proposal removed from the instrument successfully!'
-      ).removeProposalFromInstrument({
-        proposalId: proposalAndInstrumentId.proposalId,
-        instrumentId: proposalAndInstrumentId.instrumentId,
-      });
-
-      const isError = !!result.removeProposalFromInstrument.error;
-
-      if (!isError) {
-        setProposalsData(
-          proposalsData.map(prop => {
-            if (prop.id === proposalAndInstrumentId.proposalId) {
-              prop.instrumentName = null;
-            }
-
-            return prop;
-          })
-        );
-      }
-
-      setProposalAndInstrumentId({ proposalId: null, instrumentId: null });
+      return;
     }
+
+    const result = await api(
+      'Proposal removed from the instrument successfully!'
+    ).removeProposalFromInstrument({
+      proposalId: proposalAndInstrumentId.proposalId,
+      instrumentId: proposalAndInstrumentId.instrumentId,
+    });
+
+    const isError = !!result.removeProposalFromInstrument.error;
+
+    if (!isError) {
+      setProposalsData(
+        proposalsData.map(prop => {
+          if (prop.id === proposalAndInstrumentId.proposalId) {
+            prop.instrumentName = null;
+            prop.instrumentId = null;
+          }
+
+          return prop;
+        })
+      );
+    }
+
+    setProposalAndInstrumentId({ proposalId: null, instrumentId: null });
   };
 
   const RemoveScienceIcon = (): JSX.Element => <ScienceIconRemove />;
@@ -360,6 +363,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
               )
             ) {
               prop.instrumentName = instrument.name;
+              prop.instrumentId = instrument.id;
             }
 
             return prop;

--- a/src/hooks/instrument/useInstrumentsData.ts
+++ b/src/hooks/instrument/useInstrumentsData.ts
@@ -30,11 +30,17 @@ export function useInstrumentsData(
   };
 
   useEffect(() => {
+    let unmounted = false;
+
     setLoadingInstruments(true);
     if (currentRole === UserRole.USER_OFFICER) {
       api()
         .getInstruments({ callIds })
         .then(data => {
+          if (unmounted) {
+            return;
+          }
+
           if (data.instruments) {
             setInstruments(data.instruments.instruments as Instrument[]);
           }
@@ -44,12 +50,21 @@ export function useInstrumentsData(
       api()
         .getUserInstruments()
         .then(data => {
+          if (unmounted) {
+            return;
+          }
+
           if (data.me?.instruments) {
             setInstruments(data.me.instruments as Instrument[]);
           }
           setLoadingInstruments(false);
         });
     }
+
+    return () => {
+      // used to avoid unmounted component state update error
+      unmounted = true;
+    };
   }, [api, currentRole, callIds]);
 
   return {


### PR DESCRIPTION
## Description

This PR fixes a bug that prevents assigning or unassigning an instrument to the same proposal without page refresh.
<!--- Describe your changes in detail -->

## Motivation and Context

- If a proposal has an instrument assigned to it, trying to unassign and assign it again results in an error
- If a proposal has no instrument assigned to it, trying to assign one and unassign it again results in an error
- If a proposal has no instrument assigned to it, trying to assign one and assign it again result in an internal server error
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1264
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- missing properties added for assign/unassign calls
- e2e tests added
- an unmounted component state update error fixed
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
