### PR TITLE
SWAP-1250 Add required asterisk for interval and fix required checks

### DIFF
--- a/src/components/questionary/questionaryComponents/Interval/QuestionaryComponentInterval.tsx
+++ b/src/components/questionary/questionaryComponents/Interval/QuestionaryComponentInterval.tsx
@@ -1,4 +1,5 @@
 import FormControl from '@material-ui/core/FormControl';
+import FormLabel from '@material-ui/core/FormLabel';
 import Grid from '@material-ui/core/Grid';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
@@ -22,6 +23,10 @@ const useStyles = makeStyles(theme => ({
     height: '100%',
     fontSize: '17px',
     padding: '0px 5px',
+  },
+  label: {
+    marginTop: '10px',
+    marginRight: '5px',
   },
   smallLabel: {
     fontSize: '12px',
@@ -97,10 +102,10 @@ export function QuestionaryComponentInterval(props: BasicComponentProps) {
   };
 
   return (
-    <FormControl error={isError}>
+    <FormControl error={isError} required={config.required ? true : false}>
       <Grid container className={classes.container}>
         <Grid item xs={12}>
-          {question}
+          <FormLabel className={classes.label}>{question}</FormLabel>
           {config.small_label ? (
             <div className={classes.smallLabel}>{config.small_label}</div>
           ) : null}

--- a/src/components/questionary/questionaryComponents/Interval/createIntervalValidationSchema.ts
+++ b/src/components/questionary/questionaryComponents/Interval/createIntervalValidationSchema.ts
@@ -4,16 +4,26 @@ import { QuestionaryComponentDefinition } from 'components/questionary/Questiona
 import { IntervalConfig } from 'generated/sdk';
 
 export const createIntervalValidationSchema: QuestionaryComponentDefinition['createYupValidationSchema'] = answer => {
-  return Yup.object().shape({
-    min: Yup.number()
-      .transform(value => (isNaN(value) ? undefined : value))
-      .required('This field is required'),
-    max: Yup.number()
-      .transform(value => (isNaN(value) ? undefined : value))
-      .required('This field is required'),
+  const config = answer.config as IntervalConfig;
+
+  let schema = Yup.object().shape({
+    min: Yup.number().transform(value => (isNaN(value) ? undefined : value)),
+    max: Yup.number().transform(value => (isNaN(value) ? undefined : value)),
     unit:
-      (answer.config as IntervalConfig).property !== 'unitless'
+      config.property !== 'unitless'
         ? Yup.string().required('Please specify unit')
         : Yup.string().nullable(),
   });
+  if (config.required) {
+    schema = schema.shape({
+      min: Yup.number()
+        .transform(value => (isNaN(value) ? undefined : value))
+        .required('Please fill in'),
+      max: Yup.number()
+        .transform(value => (isNaN(value) ? undefined : value))
+        .required('Please fill in'),
+    });
+  }
+
+  return schema;
 };


### PR DESCRIPTION
## Description

The interval component was always required and was missing the red star, this PR fixes those things

## Motivation and Context

To fix the bug above.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

SWAP-1250 

## Changes

The most important change is the Yup validation schema update within ValidationSchema

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
