### PR TITLE
SWAP-1188 As a user officer I should be able to verify users

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
   "video": false,
-  "baseUrl": "http://127.0.0.1:3000"
+  "baseUrl": "http://127.0.0.1"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
   "video": false,
-  "baseUrl": "http://localhost"
+  "baseUrl": "http://127.0.0.1:3000"
 }

--- a/cypress/integration/eventLogs.ts
+++ b/cypress/integration/eventLogs.ts
@@ -51,13 +51,7 @@ context('Event log tests', () => {
 
     cy.contains('People').click();
 
-    let peopleTable = cy.get('[data-cy="co-proposers"]');
-
-    const lastPeoplePageButtonElement = peopleTable.find(
-      'span[title="Last Page"] > button'
-    );
-
-    lastPeoplePageButtonElement.click({ force: true });
+    cy.get('[aria-label="Search"]').type('Carlsson');
 
     cy.contains('Carlsson')
       .parent()

--- a/cypress/integration/user_administration.ts
+++ b/cypress/integration/user_administration.ts
@@ -19,6 +19,49 @@ context('User administration tests', () => {
   const newTelephone = faker.phone.phoneNumber('0##########');
   const newTelephoneAlt = faker.phone.phoneNumber('0##########');
 
+  it('should be able to verify email manually', () => {
+    cy.login('officer');
+
+    cy.contains('People').click();
+
+    cy.get('input[aria-label=Search]').type('placeholder');
+
+    cy.get("[title='Edit user']")
+      .first()
+      .click();
+
+    cy.contains('Email not verified');
+
+    cy.get('[data-cy=btn-verify-email]').click();
+
+    cy.notification({ variant: 'success', text: 'Email verified' });
+
+    cy.contains('Email not verified').should('not.be.visible');
+  });
+
+  it('should be able to remove the placeholder flag', () => {
+    cy.login('officer');
+
+    cy.contains('People').click();
+
+    cy.get('input[aria-label=Search]').type('placeholder');
+
+    cy.get("[title='Edit user']")
+      .first()
+      .click();
+
+    cy.contains('Placeholder user');
+
+    cy.get('[data-cy=btn-set-user-not-placeholder]').click();
+
+    cy.notification({
+      variant: 'success',
+      text: 'User is no longer placeholder',
+    });
+
+    cy.contains('Placeholder user').should('not.be.visible');
+  });
+
   it('Should be able administer user information', () => {
     cy.login('officer');
 
@@ -108,6 +151,6 @@ context('User administration tests', () => {
       .first()
       .click();
 
-    cy.contains('1-4 of 4');
+    cy.contains('1-5 of 5');
   });
 });

--- a/src/components/user/UpdateUserInformation.tsx
+++ b/src/components/user/UpdateUserInformation.tsx
@@ -1,12 +1,17 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import DateFnsUtils from '@date-io/date-fns'; // choose your lib
 import { updateUserValidationSchema } from '@esss-swap/duo-validation';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
+import Chip from '@material-ui/core/Chip';
 import Grid from '@material-ui/core/Grid';
 import InputLabel from '@material-ui/core/InputLabel';
+import makeStyles from '@material-ui/core/styles/makeStyles';
 import Typography from '@material-ui/core/Typography';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import AlternateEmailIcon from '@material-ui/icons/AlternateEmail';
+import DoneIcon from '@material-ui/icons/Done';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
-import makeStyles from '@material-ui/styles/makeStyles';
 import dateformat from 'dateformat';
 import { Field, Form, Formik } from 'formik';
 import { TextField } from 'formik-material-ui';
@@ -16,14 +21,14 @@ import FormikDropdown, { Option } from 'components/common/FormikDropdown';
 import FormikUICustomDatePicker from 'components/common/FormikUICustomDatePicker';
 import UOLoader from 'components/common/UOLoader';
 import { UserContext } from 'context/UserContextProvider';
-import { UpdateUserMutationVariables, User } from 'generated/sdk';
+import { UpdateUserMutationVariables, User, UserRole } from 'generated/sdk';
 import { useInstitutionsData } from 'hooks/admin/useInstitutionData';
 import { useGetFields } from 'hooks/user/useGetFields';
 import orcid from 'images/orcid.png';
 import { ButtonContainer } from 'styles/StyledComponents';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   button: {
     marginTop: '25px',
     marginLeft: '10px',
@@ -39,10 +44,15 @@ const useStyles = makeStyles({
     'margin-top': '16px',
     'margin-bottom': '19px',
   },
-});
+  chipSpace: {
+    '& > * + *': {
+      margin: theme.spacing(0.5),
+    },
+  },
+}));
 
 export default function UpdateUserInformation(props: { id: number }) {
-  const { user } = useContext(UserContext);
+  const { user, currentRole } = useContext(UserContext);
   const [userData, setUserData] = useState<User | null>(null);
   const { api } = useDataApiWithFeedback();
   const fieldsContent = useGetFields();
@@ -92,6 +102,44 @@ export default function UpdateUserInformation(props: { id: number }) {
 
   const sendUserUpdate = (variables: UpdateUserMutationVariables) => {
     return api('Updated Information').updateUser(variables);
+  };
+
+  const isUserOfficer = currentRole === UserRole.USER_OFFICER;
+
+  const handleSetUserEmailVerified = async () => {
+    const {
+      setUserEmailVerified: { error },
+    } = await api('Email verified').setUserEmailVerified({ id: props.id });
+
+    if (!error) {
+      setUserData(userData =>
+        userData
+          ? {
+              ...userData,
+              emailVerified: true,
+            }
+          : null
+      );
+    }
+  };
+
+  const handleSetUserNotPlaceholder = async () => {
+    const {
+      setUserNotPlaceholder: { error },
+    } = await api('User is no longer placeholder').setUserNotPlaceholder({
+      id: props.id,
+    });
+
+    if (!error) {
+      setUserData(userData =>
+        userData
+          ? {
+              ...userData,
+              placeholder: false,
+            }
+          : null
+      );
+    }
   };
 
   return (
@@ -145,6 +193,32 @@ export default function UpdateUserInformation(props: { id: number }) {
           <Form>
             <Typography variant="h6" gutterBottom>
               User Information
+              <Box className={classes.chipSpace}>
+                {!userData.emailVerified && (
+                  <Chip
+                    color="primary"
+                    deleteIcon={<DoneIcon />}
+                    onDelete={
+                      isUserOfficer ? handleSetUserEmailVerified : undefined
+                    }
+                    icon={<AlternateEmailIcon />}
+                    size="small"
+                    label="Email not verified"
+                  />
+                )}
+                {userData.placeholder && (
+                  <Chip
+                    color="primary"
+                    deleteIcon={<DoneIcon />}
+                    onDelete={
+                      isUserOfficer ? handleSetUserNotPlaceholder : undefined
+                    }
+                    icon={<AccountCircleIcon />}
+                    size="small"
+                    label="Placeholder user"
+                  />
+                )}
+              </Box>
             </Typography>
             <Grid container spacing={3}>
               <Grid item xs={6}>

--- a/src/components/user/UpdateUserInformation.tsx
+++ b/src/components/user/UpdateUserInformation.tsx
@@ -197,7 +197,7 @@ export default function UpdateUserInformation(props: { id: number }) {
                 {!userData.emailVerified && (
                   <Chip
                     color="primary"
-                    deleteIcon={<DoneIcon />}
+                    deleteIcon={<DoneIcon data-cy="btn-verify-email" />}
                     onDelete={
                       isUserOfficer ? handleSetUserEmailVerified : undefined
                     }
@@ -209,7 +209,9 @@ export default function UpdateUserInformation(props: { id: number }) {
                 {userData.placeholder && (
                   <Chip
                     color="primary"
-                    deleteIcon={<DoneIcon />}
+                    deleteIcon={
+                      <DoneIcon data-cy="btn-set-user-not-placeholder" />
+                    }
                     onDelete={
                       isUserOfficer ? handleSetUserNotPlaceholder : undefined
                     }

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -258,7 +258,6 @@ export enum Event {
   SEP_UPDATED = 'SEP_UPDATED',
   SEP_MEMBERS_ASSIGNED = 'SEP_MEMBERS_ASSIGNED',
   SEP_MEMBER_REMOVED = 'SEP_MEMBER_REMOVED',
-  SEP_PROPOSAL_ASSIGNED = 'SEP_PROPOSAL_ASSIGNED',
   SEP_PROPOSAL_REMOVED = 'SEP_PROPOSAL_REMOVED',
   SEP_MEMBER_ASSIGNED_TO_PROPOSAL = 'SEP_MEMBER_ASSIGNED_TO_PROPOSAL',
   SEP_MEMBER_REMOVED_FROM_PROPOSAL = 'SEP_MEMBER_REMOVED_FROM_PROPOSAL',
@@ -452,6 +451,8 @@ export type Mutation = {
   createUser: UserResponseWrap;
   updateUser: UserResponseWrap;
   updateUserRoles: UserResponseWrap;
+  setUserEmailVerified: UserResponseWrap;
+  setUserNotPlaceholder: UserResponseWrap;
   addClientLog: SuccessResponseWrap;
   applyPatches: PrepareDbResponseWrap;
   cloneSample: SampleResponseWrap;
@@ -881,6 +882,16 @@ export type MutationUpdateUserArgs = {
 export type MutationUpdateUserRolesArgs = {
   id: Scalars['Int'];
   roles?: Maybe<Array<Scalars['Int']>>;
+};
+
+
+export type MutationSetUserEmailVerifiedArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationSetUserNotPlaceholderArgs = {
+  id: Scalars['Int'];
 };
 
 
@@ -4289,7 +4300,7 @@ export type GetUserQuery = (
   { __typename?: 'Query' }
   & { user: Maybe<(
     { __typename?: 'User' }
-    & Pick<User, 'user_title' | 'username' | 'firstname' | 'middlename' | 'lastname' | 'preferredname' | 'gender' | 'nationality' | 'birthdate' | 'organisation' | 'department' | 'position' | 'email' | 'telephone' | 'telephone_alt' | 'orcid'>
+    & Pick<User, 'user_title' | 'username' | 'firstname' | 'middlename' | 'lastname' | 'preferredname' | 'gender' | 'nationality' | 'birthdate' | 'organisation' | 'department' | 'position' | 'email' | 'telephone' | 'telephone_alt' | 'orcid' | 'emailVerified' | 'placeholder'>
   )> }
 );
 
@@ -4412,6 +4423,32 @@ export type SelectRoleMutation = (
   & { selectRole: (
     { __typename?: 'TokenResponseWrap' }
     & Pick<TokenResponseWrap, 'token' | 'error'>
+  ) }
+);
+
+export type SetUserEmailVerifiedMutationVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+
+export type SetUserEmailVerifiedMutation = (
+  { __typename?: 'Mutation' }
+  & { setUserEmailVerified: (
+    { __typename?: 'UserResponseWrap' }
+    & Pick<UserResponseWrap, 'error'>
+  ) }
+);
+
+export type SetUserNotPlaceholderMutationVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+
+export type SetUserNotPlaceholderMutation = (
+  { __typename?: 'Mutation' }
+  & { setUserNotPlaceholder: (
+    { __typename?: 'UserResponseWrap' }
+    & Pick<UserResponseWrap, 'error'>
   ) }
 );
 
@@ -6228,6 +6265,8 @@ export const GetUserDocument = gql`
     telephone
     telephone_alt
     orcid
+    emailVerified
+    placeholder
   }
 }
     `;
@@ -6323,6 +6362,20 @@ export const SelectRoleDocument = gql`
     mutation selectRole($token: String!, $selectedRoleId: Int!) {
   selectRole(token: $token, selectedRoleId: $selectedRoleId) {
     token
+    error
+  }
+}
+    `;
+export const SetUserEmailVerifiedDocument = gql`
+    mutation setUserEmailVerified($id: Int!) {
+  setUserEmailVerified(id: $id) {
+    error
+  }
+}
+    `;
+export const SetUserNotPlaceholderDocument = gql`
+    mutation setUserNotPlaceholder($id: Int!) {
+  setUserNotPlaceholder(id: $id) {
     error
   }
 }
@@ -6731,6 +6784,12 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     selectRole(variables: SelectRoleMutationVariables): Promise<SelectRoleMutation> {
       return withWrapper(() => client.request<SelectRoleMutation>(print(SelectRoleDocument), variables));
+    },
+    setUserEmailVerified(variables: SetUserEmailVerifiedMutationVariables): Promise<SetUserEmailVerifiedMutation> {
+      return withWrapper(() => client.request<SetUserEmailVerifiedMutation>(print(SetUserEmailVerifiedDocument), variables));
+    },
+    setUserNotPlaceholder(variables: SetUserNotPlaceholderMutationVariables): Promise<SetUserNotPlaceholderMutation> {
+      return withWrapper(() => client.request<SetUserNotPlaceholderMutation>(print(SetUserNotPlaceholderDocument), variables));
     },
     updatePassword(variables: UpdatePasswordMutationVariables): Promise<UpdatePasswordMutation> {
       return withWrapper(() => client.request<UpdatePasswordMutation>(print(UpdatePasswordDocument), variables));

--- a/src/graphql/user/getUser.graphql
+++ b/src/graphql/user/getUser.graphql
@@ -16,5 +16,7 @@ query getUser($id: Int!) {
     telephone
     telephone_alt
     orcid
+    emailVerified
+    placeholder
   }
 }

--- a/src/graphql/user/setUserEmailVerified.graphql
+++ b/src/graphql/user/setUserEmailVerified.graphql
@@ -1,0 +1,5 @@
+mutation setUserEmailVerified($id: Int!) {
+  setUserEmailVerified(id: $id) {
+    error
+  }
+}

--- a/src/graphql/user/setUserNotPlaceholder.graphql
+++ b/src/graphql/user/setUserNotPlaceholder.graphql
@@ -1,0 +1,5 @@
+mutation setUserNotPlaceholder($id: Int!) {
+  setUserNotPlaceholder(id: $id) {
+    error
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support to manually verify email and remove the placeholder flag from a user account.
<!--- Describe your changes in detail -->

## Motivation and Context

As it is now, it is not possible to do this manually as a User Officer.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1188
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- API endpoints added for the manual updates
- UI updated
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/107
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
