### PR TITLE
SWAP-1285 In questionary same icon is used for boolean, date and add sample declaration

### DIFF
--- a/src/components/questionary/questionaryComponents/DatePicker/DatePickerDefinition.tsx
+++ b/src/components/questionary/questionaryComponents/DatePicker/DatePickerDefinition.tsx
@@ -1,4 +1,4 @@
-import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import TodayIcon from '@material-ui/icons/Today';
 import React from 'react';
 
 import { DataType } from 'generated/sdk';
@@ -17,7 +17,7 @@ export const dateDefinition: QuestionaryComponentDefinition = {
   questionTemplateRelationForm: () => QuestionTemplateRelationDateForm,
   readonly: false,
   creatable: true,
-  icon: <CheckBoxOutlineBlankIcon />,
+  icon: <TodayIcon />,
   answerRenderer: ({ answer }) => <span>{answer.value}</span>,
   createYupValidationSchema: createDateValidationSchema,
   getYupInitialValue: ({ answer }) => answer.value || '',

--- a/src/components/questionary/questionaryComponents/SampleDeclaration/SampleDeclaratonDefinition.tsx
+++ b/src/components/questionary/questionaryComponents/SampleDeclaration/SampleDeclaratonDefinition.tsx
@@ -1,4 +1,4 @@
-import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import AssignmentIcon from '@material-ui/icons/Assignment';
 import React from 'react';
 import * as Yup from 'yup';
 
@@ -18,7 +18,7 @@ export const sampleDeclarationDefinition: QuestionaryComponentDefinition = {
   questionTemplateRelationForm: () => QuestionTemplateRelationSubtemplateForm,
   readonly: false,
   creatable: true,
-  icon: <CheckBoxOutlineBlankIcon />,
+  icon: <AssignmentIcon />,
   answerRenderer: ({ answer }) => <SamplesAnswerRenderer answer={answer} />,
   createYupValidationSchema: () => {
     const schema = Yup.array().of(Yup.number());


### PR DESCRIPTION
## Description

This PR updates the icons used in the question picker.
New icons

![Screenshot 2020-12-17 143612](https://user-images.githubusercontent.com/169059/102494679-4fda7400-4075-11eb-958a-5cf6baf6447a.png)

<!--- Describe your changes in detail -->

## Motivation and Context

In questionary same icon is used for boolean, date and add sample declaration.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] existing e2e tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1285
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- icons updated
<!--- What types of changes does your code introduce? In what place? -->


## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
