### PR TITLE
SWAP-286 Signup form should not pre-fill username and password

### DIFF
--- a/src/components/user/ResetPassword.tsx
+++ b/src/components/user/ResetPassword.tsx
@@ -93,6 +93,7 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ match }) => {
               component={TextField}
               margin="normal"
               helperText="Password must contain at least 8 characters (including upper case, lower case and numbers)"
+              autoComplete="new-password"
               fullWidth
             />
             <Field
@@ -100,6 +101,7 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ match }) => {
               label="Confirm Password"
               type="password"
               component={TextField}
+              autoComplete="new-password"
               margin="normal"
               fullWidth
             />

--- a/src/components/user/SignUp.tsx
+++ b/src/components/user/SignUp.tsx
@@ -384,7 +384,7 @@ const SignUp: React.FC<SignUpProps> = props => {
                       component={TextField}
                       margin="normal"
                       fullWidth
-                      autoComplete="off"
+                      autoComplete="new-password"
                       data-cy="password"
                       helperText="Password must contain at least 8 characters (including upper case, lower case and numbers)"
                       required
@@ -397,7 +397,7 @@ const SignUp: React.FC<SignUpProps> = props => {
                       component={TextField}
                       margin="normal"
                       fullWidth
-                      autoComplete="off"
+                      autoComplete="new-password"
                       data-cy="confirmPassword"
                       required
                       disabled={!orcData}

--- a/src/components/user/UpdatePassword.tsx
+++ b/src/components/user/UpdatePassword.tsx
@@ -54,7 +54,7 @@ export default function UpdatePassword(props: { id: number }) {
                   component={TextField}
                   margin="normal"
                   fullWidth
-                  autoComplete="off"
+                  autoComplete="new-password"
                   data-cy="password"
                   helperText="Password must contain at least 8 characters (including upper case, lower case and numbers)"
                 />
@@ -67,7 +67,7 @@ export default function UpdatePassword(props: { id: number }) {
                   component={TextField}
                   margin="normal"
                   fullWidth
-                  autoComplete="off"
+                  autoComplete="new-password"
                   data-cy="confirmPassword"
                 />
               </Grid>


### PR DESCRIPTION
## Description

This PR fixes password field autocompletion on sign up and password change forms.
<!--- Describe your changes in detail -->

## Motivation and Context

If a user has saved credentials related to the User Office, they might autocomplete the password fields during sign up or password update.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] Manual
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-286
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- use `autoComplete="new-password"` 
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
