### PR TITLE
Fix for not being able to mark select as requried

### DIFF
--- a/src/components/common/FormikUICustomDependencySelector.tsx
+++ b/src/components/common/FormikUICustomDependencySelector.tsx
@@ -29,13 +29,13 @@ const FormikUICustomDependencySelector = ({
   template: Template;
   templateField: QuestionTemplateRelation;
 }) => {
-  const [dependencyId, setDependencyId] = useState<string | null>(null);
+  const [dependencyId, setDependencyId] = useState<string>('');
   const [operator, setOperator] = useState<EvaluatorOperator>(
     EvaluatorOperator.EQ
   );
   const [dependencyValue, setDependencyValue] = useState<
-    string | boolean | number | Date | null
-  >(null);
+    string | boolean | number | Date
+  >('');
 
   const [availableValues, setAvailableValues] = useState<Option[]>([]);
 
@@ -143,7 +143,6 @@ const FormikUICustomDependencySelector = ({
                     className={classes.menuItem}
                     key={option.question.proposalQuestionId}
                   >
-                    {/* {getTemplateFieldIcon(option.question.dataType)}  */}
                     {option.question.question}
                   </MenuItem>
                 );
@@ -199,8 +198,8 @@ const FormikUICustomDependencySelector = ({
       <Grid item xs={1}>
         <IconButton
           onClick={(): void => {
-            setDependencyId(null);
-            setDependencyValue(null);
+            setDependencyId('');
+            setDependencyValue('');
           }}
         >
           <ClearIcon />

--- a/src/components/questionary/questionaryComponents/MultipleChoice/QuestionMultipleChoiceForm.tsx
+++ b/src/components/questionary/questionaryComponents/MultipleChoice/QuestionMultipleChoiceForm.tsx
@@ -1,10 +1,10 @@
+import { FormControlLabel } from '@material-ui/core';
 import { Field } from 'formik';
-import { CheckboxWithLabel, TextField } from 'formik-material-ui';
+import { Checkbox, CheckboxWithLabel, TextField } from 'formik-material-ui';
 import React, { ChangeEvent, useState } from 'react';
 import * as Yup from 'yup';
 
 import FormikDropdown from 'components/common/FormikDropdown';
-import FormikUICustomCheckbox from 'components/common/FormikUICustomCheckbox';
 import FormikUICustomTable from 'components/common/FormikUICustomTable';
 import TitledContainer from 'components/common/TitledContainer';
 import { FormComponent } from 'components/questionary/QuestionaryComponentRegistry';
@@ -37,7 +37,7 @@ export const QuestionMultipleChoiceForm: FormComponent<Question> = props => {
         }),
       })}
     >
-      {formikProps => (
+      {() => (
         <>
           <Field
             name="naturalKey"
@@ -59,14 +59,17 @@ export const QuestionMultipleChoiceForm: FormComponent<Question> = props => {
           />
 
           <TitledContainer label="Constraints">
-            <Field
-              name="config.required"
+            <FormControlLabel
+              control={
+                <Field
+                  name="config.required"
+                  component={Checkbox}
+                  type="checkbox"
+                  margin="normal"
+                  inputProps={{ 'data-cy': 'required' }}
+                />
+              }
               label="Is required"
-              checked={config.required}
-              component={FormikUICustomCheckbox}
-              margin="normal"
-              fullWidth
-              inputProps={{ 'data-cy': 'required' }}
             />
           </TitledContainer>
 

--- a/src/components/questionary/questionaryComponents/MultipleChoice/QuestionTemplateRelationMultipleChoiceForm.tsx
+++ b/src/components/questionary/questionaryComponents/MultipleChoice/QuestionTemplateRelationMultipleChoiceForm.tsx
@@ -1,10 +1,10 @@
+import { FormControlLabel } from '@material-ui/core';
 import { Field } from 'formik';
-import { CheckboxWithLabel } from 'formik-material-ui';
+import { Checkbox, CheckboxWithLabel } from 'formik-material-ui';
 import React, { ChangeEvent, useState } from 'react';
 import * as Yup from 'yup';
 
 import FormikDropdown from 'components/common/FormikDropdown';
-import FormikUICustomCheckbox from 'components/common/FormikUICustomCheckbox';
 import FormikUICustomDependencySelector from 'components/common/FormikUICustomDependencySelector';
 import FormikUICustomTable from 'components/common/FormikUICustomTable';
 import TitledContainer from 'components/common/TitledContainer';
@@ -43,13 +43,17 @@ export const QuestionTemplateRelationMultipleChoiceForm: FormComponent<QuestionT
         <>
           <QuestionExcerpt question={props.field.question} />
           <TitledContainer label="Constraints">
-            <Field
-              name="config.required"
+            <FormControlLabel
+              control={
+                <Field
+                  name="config.required"
+                  component={Checkbox}
+                  margin="normal"
+                  type="checkbox"
+                  inputProps={{ 'data-cy': 'required' }}
+                />
+              }
               label="Is required"
-              component={FormikUICustomCheckbox}
-              margin="normal"
-              fullWidth
-              inputProps={{ 'data-cy': 'required' }}
             />
           </TitledContainer>
 


### PR DESCRIPTION
## Description

This is a bugfix, making the "Required" checkbox clickable in the MultipleChoice administration window

![image](https://user-images.githubusercontent.com/58165815/104308415-ea8d6d80-54d0-11eb-98d1-457f1ef82e93.png)

## Changes

Substituting checkbox that comes with Formik in favor of our own custom checkbox.
Also fixing a number of warnings

## Depends on
N/A
