### PR TITLE
SWAP-1248 Question in template must not depend on itself

### DIFF
--- a/src/models/QuestionaryFunctions.ts
+++ b/src/models/QuestionaryFunctions.ts
@@ -11,7 +11,7 @@ import {
 } from 'generated/sdk';
 import { ConditionEvaluator } from 'models/ConditionEvaluator';
 
-type AbstractField = QuestionTemplateRelation | Answer;
+export type AbstractField = QuestionTemplateRelation | Answer;
 type AbstractCollection = TemplateStep[] | QuestionaryStep[];
 
 export function getTopicById(collection: AbstractCollection, topicId: number) {


### PR DESCRIPTION
## Description

This PR prevents the user to add a dependency to a questionary which will eventually lead back to the same questionary, causing a questionary to depend on itself, resulting in an infinite loop.

## Motivation and Context
"It can be made so that question depends on itself. This will lead to an infinite loop in the frontend when the proposal is filled"

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1248
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- check if a question depends on itself 
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
