### PR TITLE
[WIP] Swap 1336 as a user i want to delete my proposal

### DIFF
--- a/cypress/integration/proposals.ts
+++ b/cypress/integration/proposals.ts
@@ -70,4 +70,24 @@ context('Proposal tests', () => {
 
     cy.get('[title="View proposal"]').should('exist');
   });
+
+  it('Should be able to delete proposal', () => {
+    const title = faker.lorem.words(2);
+    const abstract = faker.lorem.words(5);
+    cy.login('user');
+    cy.createProposal(title, abstract);
+
+    cy.contains('Submit');
+
+    cy.contains('Dashboard').click();
+
+    cy.contains(title)
+      .closest('tr')
+      .find('[title="Delete proposal"]')
+      .click();
+
+    cy.contains('OK').click();
+
+    cy.contains(title).should('not.exist');
+  });
 });

--- a/src/components/proposal/ProposalTableUser.tsx
+++ b/src/components/proposal/ProposalTableUser.tsx
@@ -21,6 +21,7 @@ export type PartialProposalsDataType = {
   submitted: boolean;
   shortCode: string;
   created: string | null;
+  proposerId: number;
 };
 
 export type UserProposalDataType = {
@@ -71,6 +72,7 @@ const ProposalTableUser: React.FC = () => {
                 shortCode: proposal.shortCode,
                 created: timeAgo(proposal.created),
                 notified: proposal.notified,
+                proposerId: proposal.proposer.id,
               };
             }),
         };

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -3014,6 +3014,7 @@ export type DeleteProposalMutation = (
   { __typename?: 'Mutation' }
   & { deleteProposal: (
     { __typename?: 'ProposalResponseWrap' }
+    & Pick<ProposalResponseWrap, 'error'>
     & { proposal: Maybe<(
       { __typename?: 'Proposal' }
       & Pick<Proposal, 'id'>
@@ -4826,6 +4827,9 @@ export type GetUserProposalsQuery = (
       & { status: (
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
+      ), proposer: (
+        { __typename?: 'BasicUserDetails' }
+        & Pick<BasicUserDetails, 'id'>
       ) }
     )> }
   )> }
@@ -5973,6 +5977,7 @@ export const DeleteProposalDocument = gql`
     proposal {
       id
     }
+    error
   }
 }
     `;
@@ -7032,6 +7037,9 @@ export const GetUserProposalsDocument = gql`
       finalStatus
       notified
       submitted
+      proposer {
+        id
+      }
     }
   }
 }

--- a/src/graphql/proposal/deleteProposal.graphql
+++ b/src/graphql/proposal/deleteProposal.graphql
@@ -3,5 +3,6 @@ mutation deleteProposal($id: Int!) {
     proposal {
       id
     }
+    error
   }
 }

--- a/src/graphql/user/getUserProposals.graphql
+++ b/src/graphql/user/getUserProposals.graphql
@@ -13,6 +13,9 @@ query getUserProposals {
       finalStatus
       notified
       submitted
+      proposer {
+        id
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

This PR aims to resolve the user story "As a user, I want to be able to delete the proposal" 

## Motivation and Context

This PR adds the delete button to the proposals table. If the user is allowed to delete the proposal (i.e. proposal is not submitted and the user is PI of the proposal), then the button is enabled, otherwise, it is disabled with the explanation in the tooltip.

![image](https://user-images.githubusercontent.com/58165815/106461928-b84eaa80-6495-11eb-892c-114c742dd370.png)

## How Has This Been Tested

- [x] Added e2e tests

## Fixes

SWAP-1336 as a user I want to be able to delete the proposal

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/148

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.

