### PR TITLE
sep bugs fixed

### DIFF
--- a/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
@@ -11,7 +11,6 @@ import Toolbar from '@material-ui/core/Toolbar';
 import { TransitionProps } from '@material-ui/core/transitions/transition';
 import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
-import PropTypes from 'prop-types';
 import React, { Ref } from 'react';
 
 import { useCheckAccess } from 'components/common/Can';
@@ -48,7 +47,6 @@ type SEPMeetingProposalViewModalProps = {
   proposalViewModalOpen: boolean;
   proposalId: number;
   sepId: number;
-  submitted: boolean;
   meetingSubmitted: (data: AdministrationFormData) => void;
   setProposalViewModalOpen: (isOpen: boolean) => void;
 };
@@ -57,7 +55,6 @@ const SEPMeetingProposalViewModal: React.FC<SEPMeetingProposalViewModalProps> = 
   proposalViewModalOpen,
   proposalId,
   sepId,
-  submitted,
   meetingSubmitted,
   setProposalViewModalOpen,
 }) => {
@@ -69,12 +66,14 @@ const SEPMeetingProposalViewModal: React.FC<SEPMeetingProposalViewModalProps> = 
   ]);
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
 
-  const finalHasWriteAccess = submitted ? isUserOfficer : hasWriteAccess;
-
   const { SEPProposalData, loading, setSEPProposalData } = useSEPProposalData(
     sepId,
     proposalId
   );
+
+  const finalHasWriteAccess = SEPProposalData?.instrumentSubmitted
+    ? isUserOfficer
+    : hasWriteAccess;
 
   const proposalData = SEPProposalData?.proposal ?? null;
 
@@ -164,15 +163,6 @@ const SEPMeetingProposalViewModal: React.FC<SEPMeetingProposalViewModalProps> = 
       </Dialog>
     </>
   );
-};
-
-SEPMeetingProposalViewModal.propTypes = {
-  proposalId: PropTypes.number.isRequired,
-  proposalViewModalOpen: PropTypes.bool.isRequired,
-  setProposalViewModalOpen: PropTypes.func.isRequired,
-  meetingSubmitted: PropTypes.func.isRequired,
-  sepId: PropTypes.number.isRequired,
-  submitted: PropTypes.bool.isRequired,
 };
 
 export default SEPMeetingProposalViewModal;

--- a/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
+++ b/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
@@ -232,7 +232,6 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
         proposalId={openProposalId || 0}
         meetingSubmitted={onMeetingSubmitted}
         sepId={sepId}
-        submitted={!!sepInstrument.submitted}
       />
       <MaterialTable
         icons={tableIcons}

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -1974,6 +1974,7 @@ export type SepProposal = {
   sepTimeAllocation: Maybe<Scalars['Int']>;
   proposal: Proposal;
   assignments: Maybe<Array<SepAssignment>>;
+  instrumentSubmitted: Scalars['Boolean'];
 };
 
 export type SepProposalResponseWrap = {
@@ -2471,7 +2472,7 @@ export type GetSepProposalQuery = (
   { __typename?: 'Query' }
   & { sepProposal: Maybe<(
     { __typename?: 'SEPProposal' }
-    & Pick<SepProposal, 'proposalId' | 'sepId' | 'sepTimeAllocation'>
+    & Pick<SepProposal, 'proposalId' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'>
     & { proposal: (
       { __typename?: 'Proposal' }
       & { proposer: Maybe<(
@@ -5924,6 +5925,7 @@ export const GetSepProposalDocument = gql`
     proposalId
     sepId
     sepTimeAllocation
+    instrumentSubmitted
     proposal {
       ...proposal
       proposer {

--- a/src/graphql/SEP/getSEPProposal.graphql
+++ b/src/graphql/SEP/getSEPProposal.graphql
@@ -4,6 +4,7 @@ query getSEPProposal($sepId: Int!, $proposalId: Int!) {
     sepId
     sepTimeAllocation
 
+    instrumentSubmitted
     proposal {
       ...proposal
       proposer {

--- a/src/hooks/SEP/useSEPProposalData.ts
+++ b/src/hooks/SEP/useSEPProposalData.ts
@@ -5,7 +5,7 @@ import { useDataApi } from 'hooks/common/useDataApi';
 
 export type SepProposalBasics = Pick<
   SepProposal,
-  'proposalId' | 'sepId' | 'sepTimeAllocation'
+  'proposalId' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'
 > & {
   proposal: Proposal;
 };


### PR DESCRIPTION
## Description

This PR fixes two SEP related bugs:
- proposals not in SEP_ status weren't accessible in the final ranking form: fixed
- it's possible to have proposals that have their instrument submitted but this is not visible on the UI: fixed
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e test
- [x] manual test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

- return proposals in sep final ranking form regardless of their current status
- include the instrument-submitted flag for each proposal
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/183
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
