### PR TITLE
Allow only SEP Reviewers to become SEP Chair/Secretary

### DIFF
--- a/cypress/integration/SEPs.ts
+++ b/cypress/integration/SEPs.ts
@@ -1,6 +1,6 @@
 import faker from 'faker';
 
-function searchUser(search: string) {
+function searchMuiTableAsync(search: string) {
   cy.get('[aria-label="Search"]').type(search);
 
   cy.get('[role="progressbar"]').should('exist');
@@ -8,7 +8,7 @@ function searchUser(search: string) {
 }
 
 function readWriteReview() {
-  cy.get('[role="dialog"').as('dialog');
+  cy.get('[role="dialog"]').as('dialog');
 
   cy.finishedLoading();
 
@@ -143,6 +143,48 @@ context('Scientific evaluation panel tests', () => {
     userMenuItems.should('not.contain', 'SEPs');
   });
 
+  it('Officer should be able to assign SEP Reviewer role', () => {
+    cy.login('officer');
+
+    cy.contains('People').click();
+    searchMuiTableAsync(sepMembers.chair.surname);
+    cy.get('[title="Edit user"]').click();
+    cy.get('[cy-data="user-page"]')
+      .contains('Settings')
+      .click();
+    cy.contains('Add role').click();
+
+    cy.get('[aria-label="Search"]').type('SEP Reviewer');
+    cy.get('[role="dialog"] input[type="checkbox"]')
+      .first()
+      .click();
+
+    cy.contains('Update').click();
+    cy.notification({
+      text: 'Roles updated successfully!',
+      variant: 'success',
+    });
+    cy.contains('People').click();
+
+    searchMuiTableAsync(sepMembers.secretary.surname);
+    cy.get('[title="Edit user"]').click();
+    cy.get('[cy-data="user-page"]')
+      .contains('Settings')
+      .click();
+    cy.contains('Add role').click();
+
+    cy.get('[aria-label="Search"]').type('SEP Reviewer');
+    cy.get('[role="dialog"] input[type="checkbox"]')
+      .first()
+      .click();
+
+    cy.contains('Update').click();
+    cy.notification({
+      text: 'Roles updated successfully!',
+      variant: 'success',
+    });
+  });
+
   it('Officer should be able to create SEP', () => {
     const { code, description } = sep1;
 
@@ -212,7 +254,7 @@ context('Scientific evaluation panel tests', () => {
 
     cy.finishedLoading();
 
-    searchUser(sepMembers.chair.surname);
+    searchMuiTableAsync(sepMembers.chair.surname);
 
     cy.get('[role="dialog"] table tbody tr')
       .first()
@@ -269,7 +311,7 @@ context('Scientific evaluation panel tests', () => {
 
     cy.finishedLoading();
 
-    searchUser(sepMembers.secretary.surname);
+    searchMuiTableAsync(sepMembers.secretary.surname);
 
     cy.get('[role="dialog"] table tbody tr')
       .first()
@@ -350,9 +392,9 @@ context('Scientific evaluation panel tests', () => {
 
     cy.finishedLoading();
 
-    searchUser(sepMembers.reviewer.surname);
+    searchMuiTableAsync(sepMembers.reviewer.surname);
 
-    cy.get('input[type="checkbox"')
+    cy.get('input[type="checkbox"]')
       .eq(1)
       .click();
 
@@ -416,9 +458,9 @@ context('Scientific evaluation panel tests', () => {
 
     cy.finishedLoading();
 
-    searchUser(sepMembers.reviewer.surname);
+    searchMuiTableAsync(sepMembers.reviewer.surname);
 
-    cy.get('input[type="checkbox"')
+    cy.get('input[type="checkbox"]')
       .eq(1)
       .click();
 
@@ -457,9 +499,9 @@ context('Scientific evaluation panel tests', () => {
 
     cy.finishedLoading();
 
-    searchUser(sepMembers.reviewer.surname);
+    searchMuiTableAsync(sepMembers.reviewer.surname);
 
-    cy.get('input[type="checkbox"')
+    cy.get('input[type="checkbox"]')
       .eq(1)
       .click();
 
@@ -925,7 +967,7 @@ context('Scientific evaluation panel tests', () => {
 
     cy.finishedLoading();
 
-    searchUser(sepMembers.secretary.surname);
+    searchMuiTableAsync(sepMembers.secretary.surname);
 
     cy.get('[title="Select user"]')
       .first()
@@ -940,7 +982,7 @@ context('Scientific evaluation panel tests', () => {
 
     cy.finishedLoading();
 
-    searchUser(sepMembers.chair.surname);
+    searchMuiTableAsync(sepMembers.chair.surname);
 
     cy.get('[title="Select user"]')
       .first()

--- a/src/components/SEP/Members/SEPMembers.tsx
+++ b/src/components/SEP/Members/SEPMembers.tsx
@@ -236,6 +236,7 @@ const SEPMembers: React.FC<SEPMembersProps> = ({
         selectedUsers={alreadySelectedMembers}
         title={'SEP Chair'}
         invitationUserRole={UserRole.SEP_CHAIR}
+        userRole={UserRole.SEP_REVIEWER}
       />
       <ParticipantModal
         show={sepSecretaryModalOpen}
@@ -244,6 +245,7 @@ const SEPMembers: React.FC<SEPMembersProps> = ({
         selectedUsers={alreadySelectedMembers}
         title={'SEP Secretary'}
         invitationUserRole={UserRole.SEP_SECRETARY}
+        userRole={UserRole.SEP_REVIEWER}
       />
       <>
         <Typography variant="h6" gutterBottom>

--- a/src/components/user/UserPage.tsx
+++ b/src/components/user/UserPage.tsx
@@ -30,7 +30,7 @@ function UserPage(props: { match: { params: { id: string } } }) {
   const classes = useStyles();
 
   return (
-    <Container maxWidth="lg">
+    <Container maxWidth="lg" cy-data="user-page">
       <SimpleTabs tabNames={['General', 'Settings', 'Logs']}>
         <UpdateUserInformation id={userId} />
         <React.Fragment>


### PR DESCRIPTION
## Description

This PR introduces some additional checks to User-to-SEP assignment: only users with SEP Reviewer role can become SEP Chair/Secretary (obviously by following the normal flow).
<!--- Describe your changes in detail -->

## Motivation and Context

Currently, any user can be selected.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e testing
- [x] manual testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

- require users to have SEP Reviewer role to assign to SEP as a SEP Chair/Secretary
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/185
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
