### PR TITLE
fix initial value for rich text input

### DIFF
--- a/src/components/questionary/questionaryComponents/RichTextInput/QuestionaryComponentRichTextInput.tsx
+++ b/src/components/questionary/questionaryComponents/RichTextInput/QuestionaryComponentRichTextInput.tsx
@@ -23,15 +23,15 @@ export function QuestionaryComponentRichTextInput(props: BasicComponentProps) {
   const {
     answer,
     onComplete,
-    formikProps: { errors, touched, initialValues },
+    formikProps: { errors, touched },
   } = props;
   const {
+    value,
     question: { proposalQuestionId, question },
   } = answer;
 
   const fieldError = getIn(errors, proposalQuestionId);
-  const initialValue = getIn(initialValues, proposalQuestionId);
-  const [stateValue, setStateValue] = useState(initialValue);
+  const [stateValue, setStateValue] = useState(value);
   const isError = getIn(touched, proposalQuestionId) && !!fieldError;
   const config = answer.config as RichTextInputConfig;
   const classes = useStyles();
@@ -52,7 +52,7 @@ export function QuestionaryComponentRichTextInput(props: BasicComponentProps) {
       <FormLabel className={classes.label}>{question}</FormLabel>
       <Editor
         id={proposalQuestionId}
-        initialValue={initialValue}
+        initialValue={value}
         init={{
           skin: false,
           content_css: false,


### PR DESCRIPTION
## Description

Before the input that a user added to a rich text question did not render when revisited as it had been wrongly initialised. 

## Motivation and Context

Fix bug
## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
