### PR TITLE
SWAP-1450 Bugfix questionary details value

### DIFF
--- a/src/components/questionary/questionaryComponents/Interval/IntervalDefinition.tsx
+++ b/src/components/questionary/questionaryComponents/Interval/IntervalDefinition.tsx
@@ -24,7 +24,7 @@ export const intervalDefinition: QuestionaryComponentDefinition = {
       const isAnswered = answer.value.min || answer.value.min; // at least one answer
       if (isAnswered) {
         const min = answer.value.min;
-        const max = answer.value.min;
+        const max = answer.value.max;
         const unit = answer.value.unit || '';
 
         return (


### PR DESCRIPTION
## Description

This bugfix addresses interval question rendering in QuestioaryDetails. It was showing min-min, but should min-max
![image](https://user-images.githubusercontent.com/58165815/110631217-90deb200-81a6-11eb-8097-67b1dfb9c8a5.png)


## Fixes

SWAP-1450

