### PR TITLE
Update Windows base image names

### DIFF
--- a/Dockerfile.dev.win
+++ b/Dockerfile.dev.win
@@ -1,5 +1,5 @@
 ARG WINDOWS_VERSION
-FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT
+FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12-servercore${WINDOWS_VERSION}
 
 # The Git repo should be mounted from the host into this directory
 WORKDIR /app

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -2,7 +2,7 @@
 ARG WINDOWS_VERSION
 
 # Stage 0, "build-stage", based on Node.js, to build and compile the frontend
-FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT as build-stage
+FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12.19.0-servercore${WINDOWS_VERSION} as build-stage
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
We've recently renamed our Node base image, so we just have to update the Dockerfiles to match the new name.

Note that the "prod" Dockerfile uses a specific Node version, while the dev version just pulls the lastest Node 12.x.

## Motivation and Context
We're trying to have simpler names for our base images.

Internally, this is part of isisbusapps/docker-base-images#39.

## How Has This Been Tested
The Dockerfiles were built locally.
