### PR TITLE
Fix empty buttons, and add tooltips to menu

### DIFF
--- a/src/components/AppToolbar/AccountActionButton.tsx
+++ b/src/components/AppToolbar/AccountActionButton.tsx
@@ -52,6 +52,7 @@ const AccountActionButton: React.FC = () => {
           color="inherit"
           aria-controls="simple-menu"
           aria-haspopup="true"
+          aria-label="Account"
           onClick={handleClick}
           data-cy="profile-page-btn"
         >

--- a/src/components/DashBoard.tsx
+++ b/src/components/DashBoard.tsx
@@ -187,7 +187,7 @@ const Dashboard: React.FC = () => {
         open={open}
       >
         <div className={classes.toolbarIcon}>
-          <IconButton onClick={handleDrawerClose}>
+          <IconButton aria-label="Close drawer" onClick={handleDrawerClose}>
             <ChevronLeftIcon />
           </IconButton>
         </div>

--- a/src/components/MenuItems.tsx
+++ b/src/components/MenuItems.tsx
@@ -211,49 +211,59 @@ const MenuItems: React.FC<MenuItemsProps> = ({ currentRole, callsData }) => {
 
   const user = (
     <div data-cy="user-menu-items">
-      <ListItem component={NavLink} to="/" exact button>
-        <ListItemIcon>
-          <DashboardIcon />
-        </ListItemIcon>
-        <ListItemText primary="Dashboard" />
-      </ListItem>
-      <ListItem
-        component={NavLink}
-        to={
-          multipleCalls
-            ? '/ProposalSelectType'
-            : `/ProposalCreate/${callsData[0]?.id}/${callsData[0]?.templateId}`
-        }
-        button
-        disabled={proposalDisabled}
-      >
-        <ListItemIcon>
-          <NoteAdd />
-        </ListItemIcon>
-        <ListItemText primary="New Proposal" />
-      </ListItem>
-      {isShipmentFeatureEnabled && (
-        <ListItem component={NavLink} to="/MyShipments" button>
+      <Tooltip title="Dashboard">
+        <ListItem component={NavLink} to="/" exact button>
           <ListItemIcon>
-            <LocalShippingIcon />
+            <DashboardIcon />
           </ListItemIcon>
-          <ListItemText primary="My shipments" />
+          <ListItemText primary="Dashboard" />
         </ListItem>
+      </Tooltip>
+      <Tooltip title="New Proposal">
+        <ListItem
+          component={NavLink}
+          to={
+            multipleCalls
+              ? '/ProposalSelectType'
+              : `/ProposalCreate/${callsData[0]?.id}/${callsData[0]?.templateId}`
+          }
+          button
+          disabled={proposalDisabled}
+        >
+          <ListItemIcon>
+            <NoteAdd />
+          </ListItemIcon>
+          <ListItemText primary="New Proposal" />
+        </ListItem>
+      </Tooltip>
+      {isShipmentFeatureEnabled && (
+        <Tooltip title="My shipments">
+          <ListItem component={NavLink} to="/MyShipments" button>
+            <ListItemIcon>
+              <LocalShippingIcon />
+            </ListItemIcon>
+            <ListItemText primary="My shipments" />
+          </ListItem>
+        </Tooltip>
       )}
       {isSchedulerEnabled && (
-        <ListItem component={NavLink} to="/MyBeamTimes" button>
-          <ListItemIcon>
-            <EventIcon />
-          </ListItemIcon>
-          <ListItemText primary="My beam times" />
-        </ListItem>
+        <Tooltip title="My Beam Times">
+          <ListItem component={NavLink} to="/MyBeamTimes" button>
+            <ListItemIcon>
+              <EventIcon />
+            </ListItemIcon>
+            <ListItemText primary="My beam times" />
+          </ListItem>
+        </Tooltip>
       )}
-      <ListItem component={NavLink} to="/HelpPage" button>
-        <ListItemIcon>
-          <Help />
-        </ListItemIcon>
-        <ListItemText primary="Help" />
-      </ListItem>
+      <Tooltip title="Help">
+        <ListItem component={NavLink} to="/HelpPage" button>
+          <ListItemIcon>
+            <Help />
+          </ListItemIcon>
+          <ListItemText primary="Help" />
+        </ListItem>
+      </Tooltip>
     </div>
   );
 

--- a/src/components/proposal/ProposalTable.tsx
+++ b/src/components/proposal/ProposalTable.tsx
@@ -15,6 +15,7 @@ import { Call } from 'generated/sdk';
 import { useDownloadPDFProposal } from 'hooks/proposal/useDownloadPDFProposal';
 import { getProposalStatus } from 'utils/helperFunctions';
 import { tableIcons } from 'utils/materialIcons';
+import { tableLocalization } from 'utils/materialLocalization';
 import { timeAgo } from 'utils/Time';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 import withConfirm, { WithConfirmType } from 'utils/withConfirm';
@@ -132,6 +133,7 @@ const ProposalTable = ({
       </Dialog>
       <MaterialTable
         icons={tableIcons}
+        localization={tableLocalization}
         title={title}
         columns={columns}
         data={partialProposalsData as PartialProposalsDataType[]}

--- a/src/components/shipments/ShipmentsTable.tsx
+++ b/src/components/shipments/ShipmentsTable.tsx
@@ -14,6 +14,7 @@ import { useDownloadPDFShipmentLabel } from 'hooks/proposal/useDownloadPDFShipme
 import { useShipments } from 'hooks/shipment/useShipments';
 import { ShipmentBasic } from 'models/ShipmentSubmissionState';
 import { tableIcons } from 'utils/materialIcons';
+import { tableLocalization } from 'utils/materialLocalization';
 import { timeAgo } from 'utils/Time';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 import withConfirm, { WithConfirmType } from 'utils/withConfirm';
@@ -87,6 +88,7 @@ const ShipmentsTable = (props: { confirm: WithConfirmType }) => {
         createModal={createModal}
         hasAccess={{ update: true, create: true, remove: true }}
         icons={tableIcons}
+        localization={tableLocalization}
         title="Shipments"
         columns={columns}
         isLoading={loadingShipments}

--- a/src/utils/materialLocalization.tsx
+++ b/src/utils/materialLocalization.tsx
@@ -1,0 +1,10 @@
+import { Localization } from 'material-table';
+
+export const tableLocalization: Localization = {
+  pagination: {
+    firstAriaLabel: 'First page',
+    previousAriaLabel: 'Previous page',
+    nextAriaLabel: 'Next page',
+    lastAriaLabel: 'Last page',
+  },
+};


### PR DESCRIPTION
## Description
### Overview
This PR fixes several (but not all) instances of the 'Empty Button' error.
Specifically it addresses **sub-issues 1, 2, and 4** documented in the [issue](https://github.com/UserOfficeProject/stfc-user-office-project/issues/111).

It **also** adds tooltips to the navigation menu (visible on hover).
![hover-menu](https://user-images.githubusercontent.com/31534888/117114225-79294180-ad83-11eb-934f-f29e501f51e0.gif)


### Details
To add ARIA labels to the `MaterialTable`, I copied the code design used for `tableIcons`.
Namely- adding a separate file which exports an object (containing ARIA label instructions in this case) which is then passed to the instantiations of the `MaterialTable`.

_Note:_ This PR only addresses pages accessible from the 'User' role.

## Motivation and Context
This PR implements accessibility requirements.
Specifically it enhances the app's screen reader support.

## How Has This Been Tested
I have manually tested the changes.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
Refs https://github.com/UserOfficeProject/stfc-user-office-project/issues/111
<!--- Does this fix a user story, if so add a reference here -->

## Changes
- ARIA labels are added to the following buttons: '**AccountActionButton**', '**Close drawer**', and all 4 `MaterialTable` **navigation** buttons (used on the 'My Proposals' and 'Shipments' tables).
- Tooltips are displayed when hovering over menu items (only those accessible to the _User_ role)
<!--- What types of changes does your code introduce? In what place? -->

## Depends on
N/A
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
