### PR TITLE
Increase font size of BottomNavigation

### DIFF
--- a/src/components/DashBoard.tsx
+++ b/src/components/DashBoard.tsx
@@ -67,7 +67,7 @@ const BottomNavItem: React.FC<BottomNavItemProps> = ({ text, linkText }) => {
       text={text}
       linkText={linkText}
       linkStyle={{
-        fontSize: '10px',
+        fontSize: '12px',
         minWidth: 'auto',
         padding: '10px',
       }}


### PR DESCRIPTION
## Description
Increases font size of the links within BottomNavigation ("_PRIVACY STATEMENT_" and "_FAQ_") from 10px --> 12px

![image](https://user-images.githubusercontent.com/31534888/117317977-ef13d280-ae81-11eb-840c-cb4a788eafbf.png)

<!--- Describe your changes in detail -->

## Motivation and Context
This makes the page more accessible.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Visual check
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
https://github.com/UserOfficeProject/stfc-user-office-project/issues/114
<!--- Does this fix a user story, if so add a reference here -->

## Changes
Font size only
<!--- What types of changes does your code introduce? In what place? -->

## Depends on
N/A
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
