### PR TITLE
Fix tests

### DIFF
--- a/src/components/proposal/ProposalSummary.tsx
+++ b/src/components/proposal/ProposalSummary.tsx
@@ -25,10 +25,6 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     justifyContent: 'flex-end',
   },
-  disabled: {
-    pointerEvents: 'none',
-    opacity: 0.7,
-  },
   button: {
     marginTop: ({ proposal }: { proposal: ProposalSubsetSubmission }) =>
       proposal.status?.id === 0 ? '40px' : 'auto',
@@ -47,7 +43,7 @@ type ProposalSummaryProps = {
   confirm: WithConfirmType;
 };
 
-function ProposalReview({ readonly, confirm }: ProposalSummaryProps) {
+function ProposalReview({ confirm }: ProposalSummaryProps) {
   const { state, dispatch } = useContext(
     QuestionaryContext
   ) as ProposalContextType;
@@ -87,10 +83,7 @@ function ProposalReview({ readonly, confirm }: ProposalSummaryProps) {
 
   return (
     <>
-      <ProposalQuestionaryReview
-        data={proposal}
-        className={readonly ? classes.disabled : undefined}
-      />
+      <ProposalQuestionaryReview data={proposal} />
       <div className={classes.buttons}>
         <NavigationFragment disabled={proposal.status?.id === 0}>
           <NavigButton


### PR DESCRIPTION
## Description

This PR aims to fix the problem with the ProposalSummary view which when marked as read-only prevented clicking the interactive "view rich text" button. 

In this view, the property read-only can be left unused for now, because there is nothing the user can edit in this view.