### PR TITLE
refactor: Rename proposal shortcode to proposal ID (BREAKING CHANGE)

### DIFF
--- a/cypress/integration/proposals.ts
+++ b/cypress/integration/proposals.ts
@@ -98,9 +98,9 @@ context('Proposal tests', () => {
   });
 
   it('Should be able clone proposal to another call', () => {
-    const shortCode = faker.random.word().split(' ')[0]; // faker random word is buggy, it ofter returns phrases
-    const surveyComment = faker.random.word().split(' ')[0];
-    const cycleComment = faker.random.word().split(' ')[0];
+    const shortCode = faker.lorem.word();
+    const surveyComment = faker.lorem.word();
+    const cycleComment = faker.lorem.word();
     const startDate = faker.date.past().toISOString().slice(0, 10);
     const endDate = faker.date.future().toISOString().slice(0, 10);
     const template = 'default template';

--- a/cypress/integration/settings.ts
+++ b/cypress/integration/settings.ts
@@ -836,7 +836,7 @@ context('Settings tests', () => {
             url: '/graphql',
             body: {
               query:
-                'query { proposalsView(filter: {}) { primaryKey title shortCode}}',
+                'query { proposalsView(filter: {}) { primaryKey title proposalId}}',
             },
             auth: {
               bearer: (accessToken as string).split(' ')[1],
@@ -883,7 +883,7 @@ context('Settings tests', () => {
             url: '/graphql',
             body: {
               query:
-                'query { proposalsView(filter: {}) { primaryKey title shortCode}}',
+                'query { proposalsView(filter: {}) { primaryKey title proposalId}}',
             },
             auth: {
               bearer: removedAccessToken.split(' ')[1],
@@ -917,7 +917,7 @@ context('Settings tests', () => {
         url: '/graphql',
         body: {
           query:
-            'query { proposals(filter: {}) { totalCount proposals { primaryKey title shortCode }}}',
+            'query { proposals(filter: {}) { totalCount proposals { primaryKey title proposalId }}}',
         },
         auth: {
           bearer: removedAccessToken.split(' ')[1],

--- a/cypress/integration/settings.ts
+++ b/cypress/integration/settings.ts
@@ -835,7 +835,8 @@ context('Settings tests', () => {
             method: 'POST',
             url: '/graphql',
             body: {
-              query: 'query { proposalsView(filter: {}) { id title shortCode}}',
+              query:
+                'query { proposalsView(filter: {}) { primaryKey title shortCode}}',
             },
             auth: {
               bearer: (accessToken as string).split(' ')[1],
@@ -881,7 +882,8 @@ context('Settings tests', () => {
             method: 'POST',
             url: '/graphql',
             body: {
-              query: 'query { proposalsView(filter: {}) { id title shortCode}}',
+              query:
+                'query { proposalsView(filter: {}) { primaryKey title shortCode}}',
             },
             auth: {
               bearer: removedAccessToken.split(' ')[1],
@@ -915,7 +917,7 @@ context('Settings tests', () => {
         url: '/graphql',
         body: {
           query:
-            'query { proposals(filter: {}) { totalCount proposals { id title shortCode }}}',
+            'query { proposals(filter: {}) { totalCount proposals { primaryKey title shortCode }}}',
         },
         auth: {
           bearer: removedAccessToken.split(' ')[1],

--- a/cypress/integration/visits.ts
+++ b/cypress/integration/visits.ts
@@ -60,7 +60,7 @@ context('visits tests', () => {
 
     cy.contains('Create').click();
 
-    cy.get("[id='mui-component-select-visit_basis.proposalId']")
+    cy.get("[id='mui-component-select-visit_basis.proposalPk']")
       .first()
       .click();
 
@@ -104,7 +104,7 @@ context('visits tests', () => {
 
     cy.contains('Proposal is required');
 
-    cy.get("[id='mui-component-select-visit_basis.proposalId']")
+    cy.get("[id='mui-component-select-visit_basis.proposalPk']")
       .first()
       .click();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1724,9 +1724,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.1.tgz",
-      "integrity": "sha512-3vITT4wS+yLcNl01EXx/zV4T673Ih+aBgkE6MY9X8Scr4Ky7XhlMOnuNNFADFlmbTcnqlEIyPWbJo4E3SJLn5Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.2.tgz",
+      "integrity": "sha512-KQkm3uDwQgSgVPvFX67Nu7tckoVA3cqYmVdk+ra37p6uVfw2YBzn1/QBjkvmAb/XtgO/Fvf/w4zGo01SYd6UDQ==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1724,9 +1724,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.3.tgz",
-      "integrity": "sha512-mf/dkE7bQtIgPO3RXGIze26u3vK6+8mTnpy5464KrP5G3uv1nj9iSoyYqb3EwiOhKyKZpsT3QOiE8EpVlf3MLQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.4.tgz",
+      "integrity": "sha512-wbLSlZQXCpLLkMFHXpx20OHlaqgXNyNV3kykwCxVtZl7ucjdB2EteBhxsgZX0SycSphhaCOR1gN4e4HFyPST8A==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1724,9 +1724,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.0.tgz",
-      "integrity": "sha512-sNv4k7aNvGIWCghFtLb1nLEDHJ0UU5HKFCC5cJwYXvSirV1AdfH6rGFb3Ab2L4/b/ZWlZwbHiD5IF4WpvCHPaw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.1.tgz",
+      "integrity": "sha512-3vITT4wS+yLcNl01EXx/zV4T673Ih+aBgkE6MY9X8Scr4Ky7XhlMOnuNNFADFlmbTcnqlEIyPWbJo4E3SJLn5Q==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1724,9 +1724,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-1.2.6.tgz",
-      "integrity": "sha512-hAMK/wa1j81pt5+uXIdcIp49d/kxJN5B88ArOdr8fhD1VpsoYBs4ANdGeWpQOvnN0H+aAtblXh1/QWTpM477GQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.0.tgz",
+      "integrity": "sha512-sNv4k7aNvGIWCghFtLb1nLEDHJ0UU5HKFCC5cJwYXvSirV1AdfH6rGFb3Ab2L4/b/ZWlZwbHiD5IF4WpvCHPaw==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1724,9 +1724,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.2.tgz",
-      "integrity": "sha512-KQkm3uDwQgSgVPvFX67Nu7tckoVA3cqYmVdk+ra37p6uVfw2YBzn1/QBjkvmAb/XtgO/Fvf/w4zGo01SYd6UDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.3.tgz",
+      "integrity": "sha512-mf/dkE7bQtIgPO3RXGIze26u3vK6+8mTnpy5464KrP5G3uv1nj9iSoyYqb3EwiOhKyKZpsT3QOiE8EpVlf3MLQ==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^2.0.3",
+    "@esss-swap/duo-validation": "^2.0.4",
     "@graphql-codegen/cli": "^1.21.5",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^1.17.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^1.2.6",
+    "@esss-swap/duo-validation": "^2.0.0",
     "@graphql-codegen/cli": "^1.21.5",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^1.17.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^2.0.2",
+    "@esss-swap/duo-validation": "^2.0.3",
     "@graphql-codegen/cli": "^1.21.5",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^1.17.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^2.0.0",
+    "@esss-swap/duo-validation": "^2.0.1",
     "@graphql-codegen/cli": "^1.21.5",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^1.17.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^2.0.1",
+    "@esss-swap/duo-validation": "^2.0.2",
     "@graphql-codegen/cli": "^1.21.5",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^1.17.7",

--- a/src/components/DashBoard.tsx
+++ b/src/components/DashBoard.tsx
@@ -230,7 +230,7 @@ const Dashboard: React.FC = () => {
       </Drawer>
       <main className={classes.content}>
         <Switch>
-          <Route path="/ProposalEdit/:proposalPK" component={ProposalEdit} />
+          <Route path="/ProposalEdit/:proposalPk" component={ProposalEdit} />
           <Route
             path="/ProposalSelectType"
             component={() => <ProposalChooseCall callsData={calls} />}

--- a/src/components/DashBoard.tsx
+++ b/src/components/DashBoard.tsx
@@ -230,7 +230,7 @@ const Dashboard: React.FC = () => {
       </Drawer>
       <main className={classes.content}>
         <Switch>
-          <Route path="/ProposalEdit/:proposalID" component={ProposalEdit} />
+          <Route path="/ProposalEdit/:proposalPK" component={ProposalEdit} />
           <Route
             path="/ProposalSelectType"
             component={() => <ProposalChooseCall callsData={calls} />}

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/FinalRankingForm.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/FinalRankingForm.tsx
@@ -54,7 +54,7 @@ const FinalRankingForm: React.FC<FinalRankingFormProps> = ({
   const [shouldSubmit, setShouldSubmit] = useState(false);
 
   const initialData = {
-    proposalPK: proposalData.id,
+    proposalPk: proposalData.id,
     commentForUser: proposalData.sepMeetingDecision?.commentForUser ?? '',
     commentForManagement:
       proposalData.sepMeetingDecision?.commentForManagement ?? '',
@@ -80,7 +80,7 @@ const FinalRankingForm: React.FC<FinalRankingFormProps> = ({
       (!isUserOfficer && shouldSubmit) || (isUserOfficer && values.submitted);
 
     const saveSepMeetingDecisionInput = {
-      proposalPK: values.proposalPK,
+      proposalPk: values.proposalPk,
       recommendation:
         ProposalEndStatus[values.recommendation as ProposalEndStatus],
       commentForUser: values.commentForUser,

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/FinalRankingForm.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/FinalRankingForm.tsx
@@ -54,7 +54,7 @@ const FinalRankingForm: React.FC<FinalRankingFormProps> = ({
   const [shouldSubmit, setShouldSubmit] = useState(false);
 
   const initialData = {
-    proposalPk: proposalData.id,
+    proposalPk: proposalData.primaryKey,
     commentForUser: proposalData.sepMeetingDecision?.commentForUser ?? '',
     commentForManagement:
       proposalData.sepMeetingDecision?.commentForManagement ?? '',

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/FinalRankingForm.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/FinalRankingForm.tsx
@@ -54,7 +54,7 @@ const FinalRankingForm: React.FC<FinalRankingFormProps> = ({
   const [shouldSubmit, setShouldSubmit] = useState(false);
 
   const initialData = {
-    proposalId: proposalData.id,
+    proposalPK: proposalData.id,
     commentForUser: proposalData.sepMeetingDecision?.commentForUser ?? '',
     commentForManagement:
       proposalData.sepMeetingDecision?.commentForManagement ?? '',
@@ -80,7 +80,7 @@ const FinalRankingForm: React.FC<FinalRankingFormProps> = ({
       (!isUserOfficer && shouldSubmit) || (isUserOfficer && values.submitted);
 
     const saveSepMeetingDecisionInput = {
-      proposalId: values.proposalId,
+      proposalPK: values.proposalPK,
       recommendation:
         ProposalEndStatus[values.recommendation as ProposalEndStatus],
       commentForUser: values.commentForUser,

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/ProposalDetails.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/ProposalDetails.tsx
@@ -97,7 +97,7 @@ const ProposalDetails: React.FC<ProposalDetailsProps> = ({ proposal }) => {
                 <TableCell>
                   <Button
                     onClick={() =>
-                      downloadPDFProposal([proposal.id], proposal.title)
+                      downloadPDFProposal([proposal.primaryKey], proposal.title)
                     }
                     color="primary"
                   >

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/ProposalDetails.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/ProposalDetails.tsx
@@ -46,7 +46,7 @@ const ProposalDetails: React.FC<ProposalDetailsProps> = ({ proposal }) => {
                 <TableCell width="25%" className={classes.textBold}>
                   ID
                 </TableCell>
-                <TableCell width="25%">{proposal.shortCode}</TableCell>
+                <TableCell width="25%">{proposal.proposalId}</TableCell>
                 <TableCell width="25%" className={classes.textBold}>
                   Title
                 </TableCell>

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
@@ -48,7 +48,7 @@ const Transition = React.forwardRef<unknown, TransitionProps>(SlideComponent);
 
 type SEPMeetingProposalViewModalProps = {
   proposalViewModalOpen: boolean;
-  proposalPK?: number | null;
+  proposalPk?: number | null;
   sepId: number;
   meetingSubmitted: (data: SepMeetingDecision) => void;
   setProposalViewModalOpen: (isOpen: boolean) => void;
@@ -56,7 +56,7 @@ type SEPMeetingProposalViewModalProps = {
 
 const SEPMeetingProposalViewModal: React.FC<SEPMeetingProposalViewModalProps> = ({
   proposalViewModalOpen,
-  proposalPK,
+  proposalPk,
   sepId,
   meetingSubmitted,
   setProposalViewModalOpen,
@@ -71,7 +71,7 @@ const SEPMeetingProposalViewModal: React.FC<SEPMeetingProposalViewModalProps> = 
 
   const { SEPProposalData, loading, setSEPProposalData } = useSEPProposalData(
     sepId,
-    proposalPK
+    proposalPk
   );
 
   const finalHasWriteAccess = SEPProposalData?.instrumentSubmitted

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
@@ -48,7 +48,7 @@ const Transition = React.forwardRef<unknown, TransitionProps>(SlideComponent);
 
 type SEPMeetingProposalViewModalProps = {
   proposalViewModalOpen: boolean;
-  proposalId?: number | null;
+  proposalPK?: number | null;
   sepId: number;
   meetingSubmitted: (data: SepMeetingDecision) => void;
   setProposalViewModalOpen: (isOpen: boolean) => void;
@@ -56,7 +56,7 @@ type SEPMeetingProposalViewModalProps = {
 
 const SEPMeetingProposalViewModal: React.FC<SEPMeetingProposalViewModalProps> = ({
   proposalViewModalOpen,
-  proposalId,
+  proposalPK,
   sepId,
   meetingSubmitted,
   setProposalViewModalOpen,
@@ -71,7 +71,7 @@ const SEPMeetingProposalViewModal: React.FC<SEPMeetingProposalViewModalProps> = 
 
   const { SEPProposalData, loading, setSEPProposalData } = useSEPProposalData(
     sepId,
-    proposalId
+    proposalPK
   );
 
   const finalHasWriteAccess = SEPProposalData?.instrumentSubmitted

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/TechnicalReviewInfo.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/TechnicalReviewInfo.tsx
@@ -72,7 +72,7 @@ const OverwriteTimeAllocationDialog = ({
 
   const initialValues = {
     ...sepProposalArgs,
-    proposalId: sepProposalArgs.proposal.id,
+    proposalPK: sepProposalArgs.proposal.id,
     sepTimeAllocation: timeAllocation,
   };
 

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/TechnicalReviewInfo.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/TechnicalReviewInfo.tsx
@@ -72,7 +72,7 @@ const OverwriteTimeAllocationDialog = ({
 
   const initialValues = {
     ...sepProposalArgs,
-    proposalPK: sepProposalArgs.proposal.id,
+    proposalPk: sepProposalArgs.proposal.id,
     sepTimeAllocation: timeAllocation,
   };
 

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/TechnicalReviewInfo.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/TechnicalReviewInfo.tsx
@@ -72,7 +72,7 @@ const OverwriteTimeAllocationDialog = ({
 
   const initialValues = {
     ...sepProposalArgs,
-    proposalPk: sepProposalArgs.proposal.id,
+    proposalPk: sepProposalArgs.proposal.primaryKey,
     sepTimeAllocation: timeAllocation,
   };
 

--- a/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
+++ b/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
@@ -242,7 +242,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
     },
     {
       title: 'ID',
-      field: 'proposal.shortCode',
+      field: 'proposal.proposalId',
     },
     { title: 'Status', field: 'proposal.status.name' },
     {

--- a/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
+++ b/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
@@ -313,7 +313,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
   const onMeetingSubmitted = (data: SepMeetingDecision) => {
     const newInstrumentProposalsData = instrumentProposalsData.map(
       (proposalData) => {
-        if (proposalData.proposal.id === data.proposalPK) {
+        if (proposalData.proposal.id === data.proposalPk) {
           return {
             ...proposalData,
             proposal: {
@@ -345,7 +345,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
       proposal: {
         ...item.proposal,
         sepMeetingDecision: {
-          proposalPK: item.proposal.id,
+          proposalPk: item.proposal.id,
           rankOrder: index + 1,
           commentForManagement:
             item.proposal.sepMeetingDecision?.commentForManagement || null,
@@ -398,7 +398,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
 
     const reorderSepMeetingDecisionProposalsInput = tableDataWithRankingsUpdated.map(
       (item) => ({
-        proposalPK: item.proposal.id,
+        proposalPk: item.proposal.id,
         rankOrder: item.proposal.sepMeetingDecision?.rankOrder,
       })
     );
@@ -459,7 +459,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
           setUrlQueryParams({ sepMeetingModal: undefined });
           refreshInstrumentProposalsData();
         }}
-        proposalPK={urlQueryParams.sepMeetingModal}
+        proposalPk={urlQueryParams.sepMeetingModal}
         meetingSubmitted={onMeetingSubmitted}
         sepId={sepId}
       />

--- a/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
+++ b/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
@@ -313,7 +313,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
   const onMeetingSubmitted = (data: SepMeetingDecision) => {
     const newInstrumentProposalsData = instrumentProposalsData.map(
       (proposalData) => {
-        if (proposalData.proposal.id === data.proposalId) {
+        if (proposalData.proposal.id === data.proposalPK) {
           return {
             ...proposalData,
             proposal: {
@@ -345,7 +345,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
       proposal: {
         ...item.proposal,
         sepMeetingDecision: {
-          proposalId: item.proposal.id,
+          proposalPK: item.proposal.id,
           rankOrder: index + 1,
           commentForManagement:
             item.proposal.sepMeetingDecision?.commentForManagement || null,
@@ -398,7 +398,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
 
     const reorderSepMeetingDecisionProposalsInput = tableDataWithRankingsUpdated.map(
       (item) => ({
-        proposalId: item.proposal.id,
+        proposalPK: item.proposal.id,
         rankOrder: item.proposal.sepMeetingDecision?.rankOrder,
       })
     );
@@ -459,7 +459,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
           setUrlQueryParams({ sepMeetingModal: undefined });
           refreshInstrumentProposalsData();
         }}
-        proposalId={urlQueryParams.sepMeetingModal}
+        proposalPK={urlQueryParams.sepMeetingModal}
         meetingSubmitted={onMeetingSubmitted}
         sepId={sepId}
       />

--- a/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
+++ b/src/components/SEP/MeetingComponents/SEPInstrumentProposalsTable.tsx
@@ -217,7 +217,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
               color="inherit"
               onClick={() =>
                 setUrlQueryParams({
-                  sepMeetingModal: rowData.proposal.id,
+                  sepMeetingModal: rowData.proposal.primaryKey,
                 })
               }
             >
@@ -313,7 +313,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
   const onMeetingSubmitted = (data: SepMeetingDecision) => {
     const newInstrumentProposalsData = instrumentProposalsData.map(
       (proposalData) => {
-        if (proposalData.proposal.id === data.proposalPk) {
+        if (proposalData.proposal.primaryKey === data.proposalPk) {
           return {
             ...proposalData,
             proposal: {
@@ -345,7 +345,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
       proposal: {
         ...item.proposal,
         sepMeetingDecision: {
-          proposalPk: item.proposal.id,
+          proposalPk: item.proposal.primaryKey,
           rankOrder: index + 1,
           commentForManagement:
             item.proposal.sepMeetingDecision?.commentForManagement || null,
@@ -398,7 +398,7 @@ const SEPInstrumentProposalsTable: React.FC<SEPInstrumentProposalsTableProps> = 
 
     const reorderSepMeetingDecisionProposalsInput = tableDataWithRankingsUpdated.map(
       (item) => ({
-        proposalPk: item.proposal.id,
+        proposalPk: item.proposal.primaryKey,
         rankOrder: item.proposal.sepMeetingDecision?.rankOrder,
       })
     );

--- a/src/components/SEP/Proposals/SEPAssignedReviewersTable.tsx
+++ b/src/components/SEP/Proposals/SEPAssignedReviewersTable.tsx
@@ -31,7 +31,7 @@ type SEPAssignedReviewersTableProps = {
   sepProposal: SEPProposalType;
   removeAssignedReviewer: (
     assignedReviewer: SepAssignment,
-    proposalPK: number
+    proposalPk: number
   ) => Promise<void>;
   updateView: (currentAssignment: SepAssignment) => void;
 };
@@ -107,7 +107,7 @@ const SEPAssignedReviewersTable: React.FC<SEPAssignedReviewersTableProps> = ({
                 ): Promise<void> =>
                   removeAssignedReviewer(
                     rowAssignmentsData,
-                    sepProposal.proposalPK
+                    sepProposal.proposalPk
                   ),
               }
             : {}
@@ -126,7 +126,7 @@ const SEPAssignedReviewersTable: React.FC<SEPAssignedReviewersTableProps> = ({
               setEditReviewID(rowData.review.id);
               setCurrentAssignment({
                 ...rowData,
-                proposalPK: sepProposal.proposalPK,
+                proposalPk: sepProposal.proposalPk,
               });
               setReviewModalOpen(true);
             },

--- a/src/components/SEP/Proposals/SEPAssignedReviewersTable.tsx
+++ b/src/components/SEP/Proposals/SEPAssignedReviewersTable.tsx
@@ -31,7 +31,7 @@ type SEPAssignedReviewersTableProps = {
   sepProposal: SEPProposalType;
   removeAssignedReviewer: (
     assignedReviewer: SepAssignment,
-    proposalId: number
+    proposalPK: number
   ) => Promise<void>;
   updateView: (currentAssignment: SepAssignment) => void;
 };
@@ -107,7 +107,7 @@ const SEPAssignedReviewersTable: React.FC<SEPAssignedReviewersTableProps> = ({
                 ): Promise<void> =>
                   removeAssignedReviewer(
                     rowAssignmentsData,
-                    sepProposal.proposalId
+                    sepProposal.proposalPK
                   ),
               }
             : {}
@@ -126,7 +126,7 @@ const SEPAssignedReviewersTable: React.FC<SEPAssignedReviewersTableProps> = ({
               setEditReviewID(rowData.review.id);
               setCurrentAssignment({
                 ...rowData,
-                proposalId: sepProposal.proposalId,
+                proposalPK: sepProposal.proposalPK,
               });
               setReviewModalOpen(true);
             },

--- a/src/components/SEP/Proposals/SEPAssignedReviewersTable.tsx
+++ b/src/components/SEP/Proposals/SEPAssignedReviewersTable.tsx
@@ -79,7 +79,7 @@ const SEPAssignedReviewersTable: React.FC<SEPAssignedReviewersTableProps> = ({
   return (
     <div className={classes.root} data-cy="sep-reviewer-assignments-table">
       <ProposalReviewModal
-        title={`Review proposal: ${sepProposal.proposal.title} (${sepProposal.proposal.shortCode})`}
+        title={`Review proposal: ${sepProposal.proposal.title} (${sepProposal.proposal.proposalId})`}
         proposalReviewModalOpen={reviewModalOpen}
         setProposalReviewModalOpen={() => {
           setReviewModalOpen(false);

--- a/src/components/SEP/Proposals/SEPProposalsAndAssignmentsTable.tsx
+++ b/src/components/SEP/Proposals/SEPProposalsAndAssignmentsTable.tsx
@@ -73,7 +73,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
     assignments?.map((assignment) => assignment.review?.grade) ?? [];
 
   const SEPProposalColumns = [
-    { title: 'ID', field: 'proposal.shortCode' },
+    { title: 'ID', field: 'proposal.proposalId' },
     {
       title: 'Title',
       field: 'proposal.title',

--- a/src/components/SEP/Proposals/SEPProposalsAndAssignmentsTable.tsx
+++ b/src/components/SEP/Proposals/SEPProposalsAndAssignmentsTable.tsx
@@ -57,7 +57,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
     setSEPProposalsData,
   } = useSEPProposalsData(sepId, selectedCallId);
   const { api } = useDataApiWithFeedback();
-  const [proposalPK, setProposalPK] = useState<null | number>(null);
+  const [proposalPk, setProposalPk] = useState<null | number>(null);
   const downloadPDFProposal = useDownloadPDFProposal();
 
   const hasRightToAssignReviewers = useCheckAccess([
@@ -132,28 +132,28 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
     proposalToRemove: SEPProposalType
   ): Promise<void> => {
     await api('Assignment removed').removeProposalsFromSep({
-      proposalPKs: [proposalToRemove.proposalPK],
+      proposalPks: [proposalToRemove.proposalPk],
       sepId,
     });
 
     setSEPProposalsData((sepProposalData) =>
       sepProposalData.filter(
         (proposalItem) =>
-          proposalItem.proposalPK !== proposalToRemove.proposalPK
+          proposalItem.proposalPk !== proposalToRemove.proposalPk
       )
     );
   };
 
   const removeAssignedReviewer = async (
     assignedReviewer: SepAssignment,
-    proposalPK: number
+    proposalPk: number
   ): Promise<void> => {
     /**
      * TODO(asztalos): merge `removeMemberFromSEPProposal` and `removeUserForReview` (same goes for creation)
      *                otherwise if one of them fails we may end up with an broken state
      */
     await api('Reviewer removed').removeMemberFromSEPProposal({
-      proposalPK,
+      proposalPk,
       sepId,
       memberId: assignedReviewer.sepMemberUserId as number,
     });
@@ -166,7 +166,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
 
     setSEPProposalsData((sepProposalData) =>
       sepProposalData.map((proposalItem) => {
-        if (proposalItem.proposalPK === proposalPK) {
+        if (proposalItem.proposalPk === proposalPk) {
           const newAssignments =
             proposalItem.assignments?.filter(
               (oldAssignment) =>
@@ -188,9 +188,9 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
   const assignMemberToSEPProposal = async (
     assignedMembers: SepAssignedMember[]
   ) => {
-    setProposalPK(null);
+    setProposalPk(null);
 
-    if (!proposalPK) {
+    if (!proposalPk) {
       return;
     }
 
@@ -198,7 +198,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
       assignSepReviewersToProposal: { rejection },
     } = await api('Members assigned').assignSepReviewersToProposal({
       memberIds: assignedMembers.map(({ id }) => id),
-      proposalPK: proposalPK,
+      proposalPk: proposalPk,
       sepId,
     });
 
@@ -207,7 +207,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
     }
 
     const { proposalReviews } = await api().getProposalReviews({
-      proposalPK,
+      proposalPk,
     });
 
     if (!proposalReviews) {
@@ -216,7 +216,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
 
     setSEPProposalsData((sepProposalData) =>
       sepProposalData.map((proposalItem) => {
-        if (proposalItem.proposalPK === proposalPK) {
+        if (proposalItem.proposalPk === proposalPk) {
           const newAssignments: SEPProposalAssignmentType[] = [
             ...(proposalItem.assignments ?? []),
             ...assignedMembers.map(({ role, ...user }) => ({
@@ -247,7 +247,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
   const GetAppIconComponent = (): JSX.Element => <GetAppIcon />;
 
   const proposalAssignments = initialValues.find(
-    (assignment) => assignment.proposalPK === proposalPK
+    (assignment) => assignment.proposalPk === proposalPk
   )?.assignments;
 
   const updateReviewStatusAndGrade = (
@@ -257,7 +257,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
   ) => {
     const newProposalsData =
       sepProposalData?.map((sepProposalsData) => {
-        if (sepProposalsData.proposalPK === editingProposalData.proposalPK) {
+        if (sepProposalsData.proposalPk === editingProposalData.proposalPk) {
           const editingProposalStatus = (currentAssignment.review as ReviewWithNextProposalStatus)
             .nextProposalStatus
             ? ((currentAssignment.review as ReviewWithNextProposalStatus)
@@ -316,7 +316,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
         }}
       >
         <ProposalReviewContent
-          proposalPK={urlQueryParams.reviewModal}
+          proposalPk={urlQueryParams.reviewModal}
           tabNames={['Proposal information', 'Technical review']}
         />
       </ProposalReviewModal>
@@ -325,8 +325,8 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
         fullWidth
         aria-labelledby="simple-modal-title"
         aria-describedby="simple-modal-description"
-        open={!!proposalPK}
-        onClose={(): void => setProposalPK(null)}
+        open={!!proposalPk}
+        onClose={(): void => setProposalPk(null)}
       >
         <DialogContent>
           <AssignSEPMemberToProposal
@@ -367,13 +367,13 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
                 ? [
                     (rowData) => ({
                       icon: AssignmentIndIcon,
-                      onClick: () => setProposalPK(rowData.proposalPK),
+                      onClick: () => setProposalPk(rowData.proposalPk),
                       tooltip: 'Assign SEP Member',
                     }),
                     (rowData) => ({
                       icon: ViewIcon,
                       onClick: () =>
-                        setUrlQueryParams({ reviewModal: rowData.proposalPK }),
+                        setUrlQueryParams({ reviewModal: rowData.proposalPk }),
                       tooltip: 'View Proposal',
                     }),
                     {
@@ -381,7 +381,7 @@ const SEPProposalsAndAssignmentsTable: React.FC<SEPProposalsAndAssignmentsTableP
                       tooltip: 'Download proposal',
                       onClick: (rowData) => {
                         downloadPDFProposal(
-                          [rowData.proposalPK],
+                          [rowData.proposalPk],
                           rowData.title
                         );
                       },

--- a/src/components/proposal/GeneralInformation.tsx
+++ b/src/components/proposal/GeneralInformation.tsx
@@ -67,7 +67,7 @@ const GeneralInformation: React.FC<GeneralInformationProps> = ({
       <div className={classes.buttons}>
         <Button
           className={classes.button}
-          onClick={() => downloadPDFProposal([data.id], data.title)}
+          onClick={() => downloadPDFProposal([data.primaryKey], data.title)}
           variant="contained"
         >
           Download PDF

--- a/src/components/proposal/ProposalAdmin.tsx
+++ b/src/components/proposal/ProposalAdmin.tsx
@@ -40,7 +40,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
 
   const initialValues = {
-    id: data.primaryKey,
+    proposalPk: data.primaryKey,
     finalStatus: data.finalStatus || ProposalEndStatus.UNSET,
     commentForUser: data.commentForUser || '',
     commentForManagement: data.commentForManagement || '',
@@ -70,6 +70,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
       setAdministration(administrationValues);
     }
   };
+  console.log(initialValues);
 
   return (
     <>

--- a/src/components/proposal/ProposalAdmin.tsx
+++ b/src/components/proposal/ProposalAdmin.tsx
@@ -19,7 +19,7 @@ import { ButtonContainer } from 'styles/StyledComponents';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 
 export type AdministrationFormData = {
-  id: number;
+  primaryKey: number;
   commentForUser: string;
   commentForManagement: string;
   finalStatus: ProposalEndStatus;
@@ -40,7 +40,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
 
   const initialValues = {
-    id: data.id,
+    id: data.primaryKey,
     finalStatus: data.finalStatus || ProposalEndStatus.UNSET,
     commentForUser: data.commentForUser || '',
     commentForManagement: data.commentForManagement || '',
@@ -81,7 +81,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
         validationSchema={administrationProposalValidationSchema}
         onSubmit={async (values): Promise<void> => {
           const administrationValues = {
-            id: data.id,
+            primaryKey: data.primaryKey,
             finalStatus:
               ProposalEndStatus[values.finalStatus as ProposalEndStatus],
             commentForUser: values.commentForUser,

--- a/src/components/proposal/ProposalAdmin.tsx
+++ b/src/components/proposal/ProposalAdmin.tsx
@@ -19,7 +19,7 @@ import { ButtonContainer } from 'styles/StyledComponents';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 
 export type AdministrationFormData = {
-  primaryKey: number;
+  proposalPk: number;
   commentForUser: string;
   commentForManagement: string;
   finalStatus: ProposalEndStatus;
@@ -81,7 +81,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
         validationSchema={administrationProposalValidationSchema}
         onSubmit={async (values): Promise<void> => {
           const administrationValues = {
-            primaryKey: data.primaryKey,
+            proposalPk: data.primaryKey,
             finalStatus:
               ProposalEndStatus[values.finalStatus as ProposalEndStatus],
             commentForUser: values.commentForUser,

--- a/src/components/proposal/ProposalContainer.tsx
+++ b/src/components/proposal/ProposalContainer.tsx
@@ -175,7 +175,7 @@ export default function ProposalContainer(props: {
       });
     } else {
       await api()
-        .getProposal({ id: proposalState.proposal.primaryKey }) // or load blankQuestionarySteps if sample is null
+        .getProposal({ primaryKey: proposalState.proposal.primaryKey }) // or load blankQuestionarySteps if sample is null
         .then((data) => {
           if (data.proposal && data.proposal.questionary?.steps) {
             dispatch({

--- a/src/components/proposal/ProposalContainer.tsx
+++ b/src/components/proposal/ProposalContainer.tsx
@@ -167,7 +167,7 @@ export default function ProposalContainer(props: {
    */
   const handleReset = async (): Promise<boolean> => {
     const proposalState = state as ProposalSubmissionState;
-    if (proposalState.proposal.id === 0) {
+    if (proposalState.proposal.primaryKey === 0) {
       // if proposal is not created yet
       dispatch({
         type: 'PROPOSAL_LOADED',
@@ -175,7 +175,7 @@ export default function ProposalContainer(props: {
       });
     } else {
       await api()
-        .getProposal({ id: proposalState.proposal.id }) // or load blankQuestionarySteps if sample is null
+        .getProposal({ id: proposalState.proposal.primaryKey }) // or load blankQuestionarySteps if sample is null
         .then((data) => {
           if (data.proposal && data.proposal.questionary?.steps) {
             dispatch({

--- a/src/components/proposal/ProposalContainer.tsx
+++ b/src/components/proposal/ProposalContainer.tsx
@@ -263,8 +263,8 @@ export default function ProposalContainer(props: {
           <Questionary
             title={state.proposal.title || 'New Proposal'}
             info={
-              state.proposal.shortCode
-                ? `Proposal ID: ${state.proposal.shortCode}`
+              state.proposal.proposalId
+                ? `Proposal ID: ${state.proposal.proposalId}`
                 : 'DRAFT'
             }
             handleReset={handleReset}

--- a/src/components/proposal/ProposalCreate.tsx
+++ b/src/components/proposal/ProposalCreate.tsx
@@ -16,7 +16,7 @@ function createProposalStub(
   proposer: BasicUserDetails
 ): ProposalSubsetSubmission {
   return {
-    id: 0,
+    primaryKey: 0,
     title: '',
     abstract: '',
     callId: callId,

--- a/src/components/proposal/ProposalCreate.tsx
+++ b/src/components/proposal/ProposalCreate.tsx
@@ -29,7 +29,7 @@ function createProposalStub(
       steps: questionarySteps,
     },
     questionaryId: 0,
-    shortCode: '',
+    proposalId: '',
     status: {
       id: 1,
       shortCode: 'DRAFT',

--- a/src/components/proposal/ProposalEdit.tsx
+++ b/src/components/proposal/ProposalEdit.tsx
@@ -9,9 +9,9 @@ import { useProposalData } from 'hooks/proposal/useProposalData';
 import ProposalContainer from './ProposalContainer';
 
 export default function ProposalEdit() {
-  const { proposalPK } = useParams<{ proposalPK: string }>();
+  const { proposalPk } = useParams<{ proposalPk: string }>();
 
-  const { proposalData } = useProposalData(+proposalPK);
+  const { proposalData } = useProposalData(+proposalPk);
 
   if (!proposalData) {
     return <UOLoader style={{ marginLeft: '50%', marginTop: '100px' }} />;

--- a/src/components/proposal/ProposalEdit.tsx
+++ b/src/components/proposal/ProposalEdit.tsx
@@ -9,9 +9,9 @@ import { useProposalData } from 'hooks/proposal/useProposalData';
 import ProposalContainer from './ProposalContainer';
 
 export default function ProposalEdit() {
-  const { proposalID } = useParams<{ proposalID: string }>();
+  const { proposalPK } = useParams<{ proposalPK: string }>();
 
-  const { proposalData } = useProposalData(+proposalID);
+  const { proposalData } = useProposalData(+proposalPK);
 
   if (!proposalData) {
     return <UOLoader style={{ marginLeft: '50%', marginTop: '100px' }} />;

--- a/src/components/proposal/ProposalQuestionaryDetails.tsx
+++ b/src/components/proposal/ProposalQuestionaryDetails.tsx
@@ -7,18 +7,18 @@ import QuestionaryDetails, {
 import { DataType } from 'generated/sdk';
 
 interface ProposalQuestionaryDetailsProps extends QuestionaryDetailsProps {
-  proposalId: number;
+  proposalPK: number;
 }
 
 function ProposalQuestionaryDetails(props: ProposalQuestionaryDetailsProps) {
-  const { proposalId, ...restProps } = props;
+  const { proposalPK, ...restProps } = props;
 
   return (
     <QuestionaryDetails
       answerRenderer={(answer) => {
         if (answer.question.dataType === DataType.SAMPLE_DECLARATION) {
           return (
-            <SamplesAnswerRenderer proposalId={proposalId} answer={answer} />
+            <SamplesAnswerRenderer proposalPK={proposalPK} answer={answer} />
           );
         } else {
           return null;

--- a/src/components/proposal/ProposalQuestionaryDetails.tsx
+++ b/src/components/proposal/ProposalQuestionaryDetails.tsx
@@ -7,18 +7,18 @@ import QuestionaryDetails, {
 import { DataType } from 'generated/sdk';
 
 interface ProposalQuestionaryDetailsProps extends QuestionaryDetailsProps {
-  proposalPK: number;
+  proposalPk: number;
 }
 
 function ProposalQuestionaryDetails(props: ProposalQuestionaryDetailsProps) {
-  const { proposalPK, ...restProps } = props;
+  const { proposalPk, ...restProps } = props;
 
   return (
     <QuestionaryDetails
       answerRenderer={(answer) => {
         if (answer.question.dataType === DataType.SAMPLE_DECLARATION) {
           return (
-            <SamplesAnswerRenderer proposalPK={proposalPK} answer={answer} />
+            <SamplesAnswerRenderer proposalPk={proposalPk} answer={answer} />
           );
         } else {
           return null;

--- a/src/components/proposal/ProposalSummary.tsx
+++ b/src/components/proposal/ProposalSummary.tsx
@@ -88,7 +88,7 @@ function ProposalReview({ readonly, confirm }: ProposalSummaryProps) {
                 () => {
                   dispatch({
                     type: 'PROPOSAL_SUBMIT_CLICKED',
-                    proposalId: proposal.id,
+                    proposalPK: proposal.id,
                   });
                 },
                 {

--- a/src/components/proposal/ProposalSummary.tsx
+++ b/src/components/proposal/ProposalSummary.tsx
@@ -88,7 +88,7 @@ function ProposalReview({ readonly, confirm }: ProposalSummaryProps) {
                 () => {
                   dispatch({
                     type: 'PROPOSAL_SUBMIT_CLICKED',
-                    proposalPk: proposal.id,
+                    proposalPk: proposal.primaryKey,
                   });
                 },
                 {
@@ -105,7 +105,9 @@ function ProposalReview({ readonly, confirm }: ProposalSummaryProps) {
             {proposal.submitted ? '✔ Submitted' : 'Submit'}
           </NavigButton>
           <Button
-            onClick={() => downloadPDFProposal([proposal.id], proposal.title)}
+            onClick={() =>
+              downloadPDFProposal([proposal.primaryKey], proposal.title)
+            }
             disabled={!allStepsComplete}
             className={classes.button}
             variant="contained"

--- a/src/components/proposal/ProposalSummary.tsx
+++ b/src/components/proposal/ProposalSummary.tsx
@@ -88,7 +88,7 @@ function ProposalReview({ readonly, confirm }: ProposalSummaryProps) {
                 () => {
                   dispatch({
                     type: 'PROPOSAL_SUBMIT_CLICKED',
-                    proposalPK: proposal.id,
+                    proposalPk: proposal.id,
                   });
                 },
                 {

--- a/src/components/proposal/ProposalTable.tsx
+++ b/src/components/proposal/ProposalTable.tsx
@@ -52,7 +52,7 @@ const ProposalTable = ({
     PartialProposalsDataType[] | undefined
   >([]);
   const [openCallSelection, setOpenCallSelection] = useState(false);
-  const [proposalToCloneId, setProposalToCloneId] = useState<number | null>(
+  const [proposalToClonePk, setProposalToCloneId] = useState<number | null>(
     null
   );
 
@@ -85,13 +85,13 @@ const ProposalTable = ({
   const cloneProposalToCall = async (call: Call) => {
     setProposalToCloneId(null);
 
-    if (!call?.id || !proposalToCloneId) {
+    if (!call?.id || !proposalToClonePk) {
       return;
     }
 
     const result = await api('Proposal cloned successfully').cloneProposal({
       callId: call.id,
-      proposalToCloneId,
+      proposalToClonePk,
     });
 
     const resultProposal = result.cloneProposal.proposal;
@@ -197,7 +197,8 @@ const ProposalTable = ({
                   async () => {
                     const deletedProposal = (
                       await api().deleteProposal({
-                        id: (rowData as PartialProposalsDataType).primaryKey,
+                        proposalPk: (rowData as PartialProposalsDataType)
+                          .primaryKey,
                       })
                     ).deleteProposal.proposal;
                     if (deletedProposal) {

--- a/src/components/proposal/ProposalTable.tsx
+++ b/src/components/proposal/ProposalTable.tsx
@@ -76,10 +76,10 @@ const ProposalTable = ({
     { title: 'Created', field: 'created' },
   ];
 
-  const [editProposalPK, setEditProposalPK] = useState(0);
+  const [editProposalPk, setEditProposalPk] = useState(0);
 
-  if (editProposalPK) {
-    return <Redirect push to={`/ProposalEdit/${editProposalPK}`} />;
+  if (editProposalPk) {
+    return <Redirect push to={`/ProposalEdit/${editProposalPk}`} />;
   }
 
   const cloneProposalToCall = async (call: Call) => {
@@ -155,7 +155,7 @@ const ProposalTable = ({
               icon: readOnly ? () => <Visibility /> : () => <Edit />,
               tooltip: readOnly ? 'View proposal' : 'Edit proposal',
               onClick: (event, rowData) =>
-                setEditProposalPK((rowData as PartialProposalsDataType).id),
+                setEditProposalPk((rowData as PartialProposalsDataType).id),
             };
           },
           {

--- a/src/components/proposal/ProposalTable.tsx
+++ b/src/components/proposal/ProposalTable.tsx
@@ -76,10 +76,10 @@ const ProposalTable = ({
     { title: 'Created', field: 'created' },
   ];
 
-  const [editProposalID, setEditProposalID] = useState(0);
+  const [editProposalPK, setEditProposalPK] = useState(0);
 
-  if (editProposalID) {
-    return <Redirect push to={`/ProposalEdit/${editProposalID}`} />;
+  if (editProposalPK) {
+    return <Redirect push to={`/ProposalEdit/${editProposalPK}`} />;
   }
 
   const cloneProposalToCall = async (call: Call) => {
@@ -155,7 +155,7 @@ const ProposalTable = ({
               icon: readOnly ? () => <Visibility /> : () => <Edit />,
               tooltip: readOnly ? 'View proposal' : 'Edit proposal',
               onClick: (event, rowData) =>
-                setEditProposalID((rowData as PartialProposalsDataType).id),
+                setEditProposalPK((rowData as PartialProposalsDataType).id),
             };
           },
           {

--- a/src/components/proposal/ProposalTable.tsx
+++ b/src/components/proposal/ProposalTable.tsx
@@ -65,7 +65,7 @@ const ProposalTable = ({
   }, [searchQuery]);
 
   const columns = [
-    { title: 'Proposal ID', field: 'shortCode' },
+    { title: 'Proposal ID', field: 'proposalId' },
     { title: 'Title', field: 'title' },
     { title: 'Status', field: 'publicStatus' },
     {
@@ -107,7 +107,7 @@ const ProposalTable = ({
         status: getProposalStatus(resultProposal),
         publicStatus: resultProposal.publicStatus,
         submitted: resultProposal.submitted,
-        shortCode: resultProposal.shortCode,
+        proposalId: resultProposal.proposalId,
         created: timeAgo(resultProposal.created),
         notified: resultProposal.notified,
         proposerId: resultProposal.proposer?.id,

--- a/src/components/proposal/ProposalTable.tsx
+++ b/src/components/proposal/ProposalTable.tsx
@@ -102,7 +102,7 @@ const ProposalTable = ({
       resultProposal
     ) {
       const newClonedProposal = {
-        id: resultProposal.id,
+        primaryKey: resultProposal.primaryKey,
         title: resultProposal.title,
         status: getProposalStatus(resultProposal),
         publicStatus: resultProposal.publicStatus,
@@ -155,14 +155,18 @@ const ProposalTable = ({
               icon: readOnly ? () => <Visibility /> : () => <Edit />,
               tooltip: readOnly ? 'View proposal' : 'Edit proposal',
               onClick: (event, rowData) =>
-                setEditProposalPk((rowData as PartialProposalsDataType).id),
+                setEditProposalPk(
+                  (rowData as PartialProposalsDataType).primaryKey
+                ),
             };
           },
           {
             icon: FileCopy,
             tooltip: 'Clone proposal',
             onClick: (event, rowData) => {
-              setProposalToCloneId((rowData as PartialProposalsDataType).id);
+              setProposalToCloneId(
+                (rowData as PartialProposalsDataType).primaryKey
+              );
               setOpenCallSelection(true);
             },
           },
@@ -171,7 +175,7 @@ const ProposalTable = ({
             tooltip: 'Download proposal',
             onClick: (event, rowData) =>
               downloadPDFProposal(
-                [(rowData as PartialProposalsDataType).id],
+                [(rowData as PartialProposalsDataType).primaryKey],
                 (rowData as PartialProposalsDataType).title
               ),
           },
@@ -193,13 +197,14 @@ const ProposalTable = ({
                   async () => {
                     const deletedProposal = (
                       await api().deleteProposal({
-                        id: (rowData as PartialProposalsDataType).id,
+                        id: (rowData as PartialProposalsDataType).primaryKey,
                       })
                     ).deleteProposal.proposal;
                     if (deletedProposal) {
                       setPartialProposalsData(
                         partialProposalsData?.filter(
-                          (item) => item.id !== deletedProposal?.id
+                          (item) =>
+                            item.primaryKey !== deletedProposal?.primaryKey
                         )
                       );
                     }

--- a/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -260,7 +260,7 @@ const ProposalTableInstrumentScientist: React.FC = () => {
         reviewItemId={urlQueryParams.reviewModal}
       >
         <ProposalReviewContent
-          proposalPK={urlQueryParams.reviewModal as number}
+          proposalPk={urlQueryParams.reviewModal as number}
           tabNames={instrumentScientistProposalReviewTabs}
         />
       </ProposalReviewModal>

--- a/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -134,7 +134,7 @@ const ProposalTableInstrumentScientist: React.FC = () => {
       removable: false,
       render: RowActionButtons,
     },
-    { title: 'Proposal ID', field: 'shortCode' },
+    { title: 'Proposal ID', field: 'proposalId' },
     {
       title: 'Title',
       field: 'title',
@@ -245,7 +245,7 @@ const ProposalTableInstrumentScientist: React.FC = () => {
   return (
     <>
       <ProposalReviewModal
-        title={`View proposal: ${proposalToReview?.title} (${proposalToReview?.shortCode})`}
+        title={`View proposal: ${proposalToReview?.title} (${proposalToReview?.proposalId})`}
         proposalReviewModalOpen={!!urlQueryParams.reviewModal}
         setProposalReviewModalOpen={(updatedProposal?: Proposal) => {
           setProposalsData(

--- a/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -103,7 +103,7 @@ const ProposalTableInstrumentScientist: React.FC = () => {
           <IconButton
             data-cy="view-proposal"
             onClick={() => {
-              setUrlQueryParams({ reviewModal: rowData.id });
+              setUrlQueryParams({ reviewModal: rowData.primaryKey });
             }}
             style={iconButtonStyle}
           >
@@ -114,7 +114,9 @@ const ProposalTableInstrumentScientist: React.FC = () => {
         <Tooltip title="Download proposal as pdf">
           <IconButton
             data-cy="download-proposal"
-            onClick={() => downloadPDFProposal([rowData.id], rowData.title)}
+            onClick={() =>
+              downloadPDFProposal([rowData.primaryKey], rowData.title)
+            }
             style={iconButtonStyle}
           >
             <GetAppIcon />
@@ -232,7 +234,7 @@ const ProposalTableInstrumentScientist: React.FC = () => {
   const GetAppIconComponent = (): JSX.Element => <GetAppIcon />;
 
   const proposalToReview = proposalsData.find(
-    (proposal) => proposal.id === urlQueryParams.reviewModal
+    (proposal) => proposal.primaryKey === urlQueryParams.reviewModal
   );
 
   const instrumentScientistProposalReviewTabs: TabNames[] = [
@@ -248,7 +250,7 @@ const ProposalTableInstrumentScientist: React.FC = () => {
         setProposalReviewModalOpen={(updatedProposal?: Proposal) => {
           setProposalsData(
             proposalsData.map((proposal) => {
-              if (proposal.id === updatedProposal?.id) {
+              if (proposal.primaryKey === updatedProposal?.primaryKey) {
                 return updatedProposal;
               } else {
                 return proposal;
@@ -316,7 +318,7 @@ const ProposalTableInstrumentScientist: React.FC = () => {
             tooltip: 'Download proposals in PDF',
             onClick: (event, rowData): void => {
               downloadPDFProposal(
-                (rowData as Proposal[]).map((row) => row.id),
+                (rowData as Proposal[]).map((row) => row.primaryKey),
                 (rowData as Proposal[])[0].title
               );
             },

--- a/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -260,7 +260,7 @@ const ProposalTableInstrumentScientist: React.FC = () => {
         reviewItemId={urlQueryParams.reviewModal}
       >
         <ProposalReviewContent
-          proposalId={urlQueryParams.reviewModal as number}
+          proposalPK={urlQueryParams.reviewModal as number}
           tabNames={instrumentScientistProposalReviewTabs}
         />
       </ProposalReviewModal>

--- a/src/components/proposal/ProposalTableOfficer.tsx
+++ b/src/components/proposal/ProposalTableOfficer.tsx
@@ -29,7 +29,7 @@ import {
   Proposal,
   ProposalsFilter,
   ProposalStatus,
-  ProposalPKWithCallId,
+  ProposalPkWithCallId,
   Sep,
 } from 'generated/sdk';
 import { useLocalStorage } from 'hooks/common/useLocalStorage';
@@ -58,7 +58,7 @@ type ProposalTableOfficerProps = {
   confirm: WithConfirmType;
 };
 
-type ProposalWithCallInstrumentAndSepId = ProposalPKWithCallId & {
+type ProposalWithCallInstrumentAndSepId = ProposalPkWithCallId & {
   instrumentId: number | null;
   sepId: number | null;
 };
@@ -355,7 +355,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       const result = await api(
         'Proposal/s removed from the SEP successfully!'
       ).removeProposalsFromSep({
-        proposalPKs: selectedProposals.map(
+        proposalPks: selectedProposals.map(
           (selectedProposal) => selectedProposal.id
         ),
         sepId: selectedProposals[0].sepId as number,
@@ -417,7 +417,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       const result = await api(
         'Proposal/s removed from the instrument successfully!'
       ).removeProposalsFromInstrument({
-        proposalPKs: selectedProposals.map(
+        proposalPks: selectedProposals.map(
           (selectedProposal) => selectedProposal.id
         ),
       });
@@ -608,7 +608,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         reviewItemId={proposalToReview?.id}
       >
         <ProposalReviewContent
-          proposalPK={proposalToReview?.id as number}
+          proposalPk={proposalToReview?.id as number}
           tabNames={userOfficerProposalReviewTabs}
         />
       </ProposalReviewModal>

--- a/src/components/proposal/ProposalTableOfficer.tsx
+++ b/src/components/proposal/ProposalTableOfficer.tsx
@@ -213,7 +213,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       removable: false,
       render: RowActionButtons,
     },
-    { title: 'Proposal ID', field: 'shortCode' },
+    { title: 'Proposal ID', field: 'proposalId' },
     {
       title: 'Title',
       field: 'title',
@@ -600,7 +600,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         </DialogContent>
       </Dialog>
       <ProposalReviewModal
-        title={`View proposal: ${proposalToReview?.title} (${proposalToReview?.shortCode})`}
+        title={`View proposal: ${proposalToReview?.title} (${proposalToReview?.proposalId})`}
         proposalReviewModalOpen={!!urlQueryParams.reviewModal}
         setProposalReviewModalOpen={(updatedProposal?: Proposal) => {
           setProposalsData(

--- a/src/components/proposal/ProposalTableOfficer.tsx
+++ b/src/components/proposal/ProposalTableOfficer.tsx
@@ -83,7 +83,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
     ProposalViewData[]
   >([]);
   const [openCallSelection, setOpenCallSelection] = useState(false);
-  const [proposalToCloneId, setProposalToCloneId] = useState<number | null>(
+  const [proposalToClonePk, setProposalToClonePk] = useState<number | null>(
     null
   );
 
@@ -182,7 +182,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           <IconButton
             data-cy="clone-proposal"
             onClick={() => {
-              setProposalToCloneId(rowData.primaryKey);
+              setProposalToClonePk(rowData.primaryKey);
               setOpenCallSelection(true);
             }}
             style={iconButtonStyle}
@@ -286,7 +286,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       const {
         notifyProposal: { rejection },
       } = await api('Notification sent successfully').notifyProposal({
-        id: proposal.primaryKey,
+        proposalPk: proposal.primaryKey,
       });
 
       if (rejection) {
@@ -306,7 +306,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
     selectedProposals.forEach(async (proposal) => {
       const {
         deleteProposal: { rejection },
-      } = await api().deleteProposal({ id: proposal.primaryKey });
+      } = await api().deleteProposal({ proposalPk: proposal.primaryKey });
 
       if (rejection) {
         return;
@@ -452,15 +452,15 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
   };
 
   const cloneProposalToCall = async (call: Call) => {
-    setProposalToCloneId(null);
+    setProposalToClonePk(null);
 
-    if (!call?.id || !proposalToCloneId) {
+    if (!call?.id || !proposalToClonePk) {
       return;
     }
 
     const result = await api('Proposal cloned successfully').cloneProposal({
       callId: call.id,
-      proposalToCloneId,
+      proposalToClonePk,
     });
 
     const resultProposal = result.cloneProposal.proposal;

--- a/src/components/proposal/ProposalTableOfficer.tsx
+++ b/src/components/proposal/ProposalTableOfficer.tsx
@@ -108,9 +108,9 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       setPreselectedProposalsData((preselectedProposalsData) => {
         const selected: ProposalWithCallInstrumentAndSepId[] = [];
         const preselected = preselectedProposalsData.map((proposal) => {
-          if (selection.has(proposal.id.toString())) {
+          if (selection.has(proposal.primaryKey.toString())) {
             selected.push({
-              id: proposal.id,
+              primaryKey: proposal.primaryKey,
               callId: proposal.callId,
               instrumentId: proposal.instrumentId,
               sepId: proposal.sepId,
@@ -120,7 +120,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           return {
             ...proposal,
             tableData: {
-              checked: selection.has(proposal.id.toString()),
+              checked: selection.has(proposal.primaryKey.toString()),
             },
           };
         });
@@ -171,7 +171,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           <IconButton
             data-cy="view-proposal"
             onClick={() => {
-              setUrlQueryParams({ reviewModal: rowData.id });
+              setUrlQueryParams({ reviewModal: rowData.primaryKey });
             }}
             style={iconButtonStyle}
           >
@@ -182,7 +182,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           <IconButton
             data-cy="clone-proposal"
             onClick={() => {
-              setProposalToCloneId(rowData.id);
+              setProposalToCloneId(rowData.primaryKey);
               setOpenCallSelection(true);
             }}
             style={iconButtonStyle}
@@ -193,7 +193,9 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         <Tooltip title="Download proposal as pdf">
           <IconButton
             data-cy="download-proposal"
-            onClick={() => downloadPDFProposal([rowData.id], rowData.title)}
+            onClick={() =>
+              downloadPDFProposal([rowData.primaryKey], rowData.title)
+            }
             style={iconButtonStyle}
           >
             <GetAppIcon />
@@ -284,7 +286,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       const {
         notifyProposal: { rejection },
       } = await api('Notification sent successfully').notifyProposal({
-        id: proposal.id,
+        id: proposal.primaryKey,
       });
 
       if (rejection) {
@@ -294,7 +296,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       setProposalsData((proposalsData) =>
         proposalsData.map((prop) => ({
           ...prop,
-          notified: prop.id === proposal.id,
+          notified: prop.primaryKey === proposal.primaryKey,
         }))
       );
     });
@@ -304,14 +306,16 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
     selectedProposals.forEach(async (proposal) => {
       const {
         deleteProposal: { rejection },
-      } = await api().deleteProposal({ id: proposal.id });
+      } = await api().deleteProposal({ id: proposal.primaryKey });
 
       if (rejection) {
         return;
       }
 
       setProposalsData((proposalsData) =>
-        proposalsData.filter(({ id }) => id !== proposal.id)
+        proposalsData.filter(
+          ({ primaryKey }) => primaryKey !== proposal.primaryKey
+        )
       );
     });
   };
@@ -322,7 +326,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         'Proposal/s assigned to the selected SEP successfully!'
       ).assignProposalsToSep({
         proposals: selectedProposals.map((selectedProposal) => ({
-          id: selectedProposal.id,
+          primaryKey: selectedProposal.primaryKey,
           callId: selectedProposal.callId,
         })),
         sepId: sep.id,
@@ -335,7 +339,8 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           proposalsData.map((prop) => {
             if (
               selectedProposals.find(
-                (selectedProposal) => selectedProposal.id === prop.id
+                (selectedProposal) =>
+                  selectedProposal.primaryKey === prop.primaryKey
               )
             ) {
               prop.sepCode = sep.code;
@@ -356,7 +361,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         'Proposal/s removed from the SEP successfully!'
       ).removeProposalsFromSep({
         proposalPks: selectedProposals.map(
-          (selectedProposal) => selectedProposal.id
+          (selectedProposal) => selectedProposal.primaryKey
         ),
         sepId: selectedProposals[0].sepId as number,
       });
@@ -368,7 +373,8 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           proposalsData.map((prop) => {
             if (
               selectedProposals.find(
-                (selectedProposal) => selectedProposal.id === prop.id
+                (selectedProposal) =>
+                  selectedProposal.primaryKey === prop.primaryKey
               )
             ) {
               prop.sepCode = null;
@@ -390,7 +396,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         'Proposal/s assigned to the selected instrument successfully!'
       ).assignProposalsToInstrument({
         proposals: selectedProposals.map((selectedProposal) => ({
-          id: selectedProposal.id,
+          primaryKey: selectedProposal.primaryKey,
           callId: selectedProposal.callId,
         })),
         instrumentId: instrument.id,
@@ -402,7 +408,8 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           proposalsData.map((prop) => {
             if (
               selectedProposals.find(
-                (selectedProposal) => selectedProposal.id === prop.id
+                (selectedProposal) =>
+                  selectedProposal.primaryKey === prop.primaryKey
               )
             ) {
               prop.instrumentName = instrument.name;
@@ -418,7 +425,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         'Proposal/s removed from the instrument successfully!'
       ).removeProposalsFromInstrument({
         proposalPks: selectedProposals.map(
-          (selectedProposal) => selectedProposal.id
+          (selectedProposal) => selectedProposal.primaryKey
         ),
       });
 
@@ -429,7 +436,8 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           proposalsData.map((prop) => {
             if (
               selectedProposals.find(
-                (selectedProposal) => selectedProposal.id === prop.id
+                (selectedProposal) =>
+                  selectedProposal.primaryKey === prop.primaryKey
               )
             ) {
               prop.instrumentName = null;
@@ -475,7 +483,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         `Proposal${shouldAddPluralLetter} status changed successfully!`
       ).changeProposalsStatus({
         proposals: selectedProposals.map((selectedProposal) => ({
-          id: selectedProposal.id,
+          primaryKey: selectedProposal.primaryKey,
           callId: selectedProposal.callId,
         })),
         statusId: status.id,
@@ -490,7 +498,8 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           proposalsData.map((prop) => {
             if (
               selectedProposals.find(
-                (selectedProposal) => selectedProposal.id === prop.id
+                (selectedProposal) =>
+                  selectedProposal.primaryKey === prop.primaryKey
               )
             ) {
               prop.statusId = status.id;
@@ -516,7 +525,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
   );
 
   const proposalToReview = proposalsData.find(
-    (proposal) => proposal.id === urlQueryParams.reviewModal
+    (proposal) => proposal.primaryKey === urlQueryParams.reviewModal
   );
 
   const userOfficerProposalReviewTabs: TabNames[] = [
@@ -596,7 +605,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         setProposalReviewModalOpen={(updatedProposal?: Proposal) => {
           setProposalsData(
             proposalsData.map((proposal) => {
-              if (proposal.id === updatedProposal?.id) {
+              if (proposal.primaryKey === updatedProposal?.primaryKey) {
                 return fromProposalToProposalView(updatedProposal);
               } else {
                 return proposal;
@@ -605,10 +614,10 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
           );
           setUrlQueryParams({ reviewModal: undefined });
         }}
-        reviewItemId={proposalToReview?.id}
+        reviewItemId={proposalToReview?.primaryKey}
       >
         <ProposalReviewContent
-          proposalPk={proposalToReview?.id as number}
+          proposalPk={proposalToReview?.primaryKey as number}
           tabNames={userOfficerProposalReviewTabs}
         />
       </ProposalReviewModal>
@@ -627,7 +636,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
             selection:
               selectedItems.length > 0
                 ? selectedItems.map((selectedItem) =>
-                    selectedItem.id.toString()
+                    selectedItem.primaryKey.toString()
                   )
                 : undefined,
           }));
@@ -645,7 +654,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
             tooltip: 'Download proposals in PDF',
             onClick: (event, rowData): void => {
               downloadPDFProposal(
-                (rowData as ProposalViewData[]).map((row) => row.id),
+                (rowData as ProposalViewData[]).map((row) => row.primaryKey),
                 (rowData as ProposalViewData[])[0].title
               );
             },
@@ -656,7 +665,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
             tooltip: 'Export proposals in Excel',
             onClick: (event, rowData): void => {
               downloadXLSXProposal(
-                (rowData as ProposalViewData[]).map((row) => row.id),
+                (rowData as ProposalViewData[]).map((row) => row.primaryKey),
                 (rowData as ProposalViewData[])[0].title
               );
             },

--- a/src/components/proposal/ProposalTableOfficer.tsx
+++ b/src/components/proposal/ProposalTableOfficer.tsx
@@ -29,7 +29,7 @@ import {
   Proposal,
   ProposalsFilter,
   ProposalStatus,
-  ProposalIdWithCallId,
+  ProposalPKWithCallId,
   Sep,
 } from 'generated/sdk';
 import { useLocalStorage } from 'hooks/common/useLocalStorage';
@@ -58,7 +58,7 @@ type ProposalTableOfficerProps = {
   confirm: WithConfirmType;
 };
 
-type ProposalWithCallInstrumentAndSepId = ProposalIdWithCallId & {
+type ProposalWithCallInstrumentAndSepId = ProposalPKWithCallId & {
   instrumentId: number | null;
   sepId: number | null;
 };
@@ -355,7 +355,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       const result = await api(
         'Proposal/s removed from the SEP successfully!'
       ).removeProposalsFromSep({
-        proposalIds: selectedProposals.map(
+        proposalPKs: selectedProposals.map(
           (selectedProposal) => selectedProposal.id
         ),
         sepId: selectedProposals[0].sepId as number,
@@ -417,7 +417,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       const result = await api(
         'Proposal/s removed from the instrument successfully!'
       ).removeProposalsFromInstrument({
-        proposalIds: selectedProposals.map(
+        proposalPKs: selectedProposals.map(
           (selectedProposal) => selectedProposal.id
         ),
       });
@@ -608,7 +608,7 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         reviewItemId={proposalToReview?.id}
       >
         <ProposalReviewContent
-          proposalId={proposalToReview?.id as number}
+          proposalPK={proposalToReview?.id as number}
           tabNames={userOfficerProposalReviewTabs}
         />
       </ProposalReviewModal>

--- a/src/components/proposal/ProposalTableUser.tsx
+++ b/src/components/proposal/ProposalTableUser.tsx
@@ -8,7 +8,7 @@ import { timeAgo } from 'utils/Time';
 import ProposalTable from './ProposalTable';
 
 export type PartialProposalsDataType = {
-  id: number;
+  primaryKey: number;
   title: string;
   status: string | null;
   publicStatus: ProposalPublicStatus;
@@ -50,7 +50,7 @@ const ProposalTableUser: React.FC = () => {
             })
             .map((proposal) => {
               return {
-                id: proposal.id,
+                primaryKey: proposal.primaryKey,
                 title: proposal.title,
                 status: getProposalStatus(proposal),
                 publicStatus: proposal.publicStatus,

--- a/src/components/proposal/ProposalTableUser.tsx
+++ b/src/components/proposal/ProposalTableUser.tsx
@@ -15,7 +15,7 @@ export type PartialProposalsDataType = {
   finalStatus?: string;
   notified?: boolean;
   submitted: boolean;
-  shortCode: string;
+  proposalId: string;
   created: string | null;
   call?: Maybe<Pick<Call, 'shortCode' | 'id' | 'isActive'>>;
   proposerId?: number;
@@ -55,7 +55,7 @@ const ProposalTableUser: React.FC = () => {
                 status: getProposalStatus(proposal),
                 publicStatus: proposal.publicStatus,
                 submitted: proposal.submitted,
-                shortCode: proposal.shortCode,
+                proposalId: proposal.proposalId,
                 created: timeAgo(proposal.created),
                 notified: proposal.notified,
                 proposerId: proposal.proposer?.id,

--- a/src/components/proposalBooking/ExperimentTimesTable.tsx
+++ b/src/components/proposalBooking/ExperimentTimesTable.tsx
@@ -28,7 +28,7 @@ export default function ExperimentsTable({
       isLoading={isLoading}
       columns={[
         { title: 'Proposal title', field: 'proposal.title' },
-        { title: 'Proposal short code', field: 'proposal.shortCode' },
+        { title: 'Proposal ID', field: 'proposal.proposalId' },
         {
           title: 'Starts at',
           field: 'startsAt',

--- a/src/components/proposalBooking/UserUpcomingExperimentsTable.tsx
+++ b/src/components/proposalBooking/UserUpcomingExperimentsTable.tsx
@@ -139,7 +139,7 @@ export default function UserUpcomingExperimentsTable() {
           isLoading={loading}
           columns={[
             { title: 'Proposal title', field: 'proposal.title' },
-            { title: 'Proposal short code', field: 'proposal.shortCode' },
+            { title: 'Proposal ID', field: 'proposal.proposalId' },
             {
               title: 'Starts at',
               field: 'startsAt',

--- a/src/components/questionary/questionaryComponents/ProposalBasis/QuestionaryComponentProposalBasis.tsx
+++ b/src/components/questionary/questionaryComponents/ProposalBasis/QuestionaryComponentProposalBasis.tsx
@@ -143,7 +143,7 @@ const proposalBasisPreSubmit = () => async ({
 
   if (primaryKey > 0) {
     const result = await api.updateProposal({
-      id: primaryKey,
+      proposalPk: primaryKey,
       title: title,
       abstract: abstract,
       users: users.map((user) => user.id),
@@ -163,7 +163,7 @@ const proposalBasisPreSubmit = () => async ({
 
     if (createResult.createProposal.proposal) {
       const updateResult = await api.updateProposal({
-        id: createResult.createProposal.proposal.primaryKey,
+        proposalPk: createResult.createProposal.proposal.primaryKey,
         title: title,
         abstract: abstract,
         users: users.map((user) => user.id),

--- a/src/components/questionary/questionaryComponents/ProposalBasis/QuestionaryComponentProposalBasis.tsx
+++ b/src/components/questionary/questionaryComponents/ProposalBasis/QuestionaryComponentProposalBasis.tsx
@@ -137,13 +137,13 @@ const proposalBasisPreSubmit = () => async ({
   state,
 }: SubmitActionDependencyContainer) => {
   const proposal = (state as ProposalSubmissionState).proposal;
-  const { id, title, abstract, users, proposer, callId } = proposal;
+  const { primaryKey, title, abstract, users, proposer, callId } = proposal;
 
   let returnValue = state.questionaryId;
 
-  if (id > 0) {
+  if (primaryKey > 0) {
     const result = await api.updateProposal({
-      id: id,
+      id: primaryKey,
       title: title,
       abstract: abstract,
       users: users.map((user) => user.id),
@@ -163,7 +163,7 @@ const proposalBasisPreSubmit = () => async ({
 
     if (createResult.createProposal.proposal) {
       const updateResult = await api.updateProposal({
-        id: createResult.createProposal.proposal.id,
+        id: createResult.createProposal.proposal.primaryKey,
         title: title,
         abstract: abstract,
         users: users.map((user) => user.id),

--- a/src/components/questionary/questionaryComponents/SampleBasis/QuestionaryComponentSampleBasis.tsx
+++ b/src/components/questionary/questionaryComponents/SampleBasis/QuestionaryComponentSampleBasis.tsx
@@ -83,7 +83,7 @@ const sampleBasisPreSubmit = () => async ({
     const result = await api.createSample({
       title: title,
       templateId: state.templateId,
-      proposalPK: sample.proposalPK,
+      proposalPk: sample.proposalPk,
       questionId: sample.questionId,
     });
 

--- a/src/components/questionary/questionaryComponents/SampleBasis/QuestionaryComponentSampleBasis.tsx
+++ b/src/components/questionary/questionaryComponents/SampleBasis/QuestionaryComponentSampleBasis.tsx
@@ -83,7 +83,7 @@ const sampleBasisPreSubmit = () => async ({
     const result = await api.createSample({
       title: title,
       templateId: state.templateId,
-      proposalId: sample.proposalId,
+      proposalPK: sample.proposalPK,
       questionId: sample.questionId,
     });
 

--- a/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
+++ b/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
@@ -49,7 +49,7 @@ const sampleToListRow = (
 function createSampleStub(
   templateId: number,
   questionarySteps: QuestionaryStep[],
-  proposalPK: number,
+  proposalPk: number,
   questionId: string
 ): SampleWithQuestionary {
   return {
@@ -68,7 +68,7 @@ function createSampleStub(
     safetyComment: '',
     safetyStatus: SampleStatus.PENDING_EVALUATION,
     title: '',
-    proposalPK: proposalPK,
+    proposalPk: proposalPk,
   };
 }
 
@@ -164,9 +164,9 @@ function QuestionaryComponentSampleDeclaration(
                   );
                 }
 
-                const proposalPK = state.proposal.id;
+                const proposalPk = state.proposal.id;
                 const questionId = props.answer.question.id;
-                if (proposalPK <= 0 || !questionId) {
+                if (proposalPk <= 0 || !questionId) {
                   throw new Error(
                     'Sample Declaration is missing proposal id and/or question id'
                   );
@@ -185,7 +185,7 @@ function QuestionaryComponentSampleDeclaration(
                       const sampleStub = createSampleStub(
                         templateId,
                         blankSteps,
-                        proposalPK,
+                        proposalPk,
                         questionId
                       );
                       setSelectedSample(sampleStub);
@@ -221,7 +221,7 @@ function QuestionaryComponentSampleDeclaration(
                       .getSamplesWithQuestionaryStatus({
                         filter: {
                           questionId: answer.question.id,
-                          proposalPK: state.proposal.id,
+                          proposalPk: state.proposal.id,
                         },
                       })
                       .then((result) => {

--- a/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
+++ b/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
@@ -49,7 +49,7 @@ const sampleToListRow = (
 function createSampleStub(
   templateId: number,
   questionarySteps: QuestionaryStep[],
-  proposalId: number,
+  proposalPK: number,
   questionId: string
 ): SampleWithQuestionary {
   return {
@@ -68,7 +68,7 @@ function createSampleStub(
     safetyComment: '',
     safetyStatus: SampleStatus.PENDING_EVALUATION,
     title: '',
-    proposalId: proposalId,
+    proposalPK: proposalPK,
   };
 }
 
@@ -164,9 +164,9 @@ function QuestionaryComponentSampleDeclaration(
                   );
                 }
 
-                const proposalId = state.proposal.id;
+                const proposalPK = state.proposal.id;
                 const questionId = props.answer.question.id;
-                if (proposalId <= 0 || !questionId) {
+                if (proposalPK <= 0 || !questionId) {
                   throw new Error(
                     'Sample Declaration is missing proposal id and/or question id'
                   );
@@ -185,7 +185,7 @@ function QuestionaryComponentSampleDeclaration(
                       const sampleStub = createSampleStub(
                         templateId,
                         blankSteps,
-                        proposalId,
+                        proposalPK,
                         questionId
                       );
                       setSelectedSample(sampleStub);
@@ -221,7 +221,7 @@ function QuestionaryComponentSampleDeclaration(
                       .getSamplesWithQuestionaryStatus({
                         filter: {
                           questionId: answer.question.id,
-                          proposalId: state.proposal.id,
+                          proposalPK: state.proposal.id,
                         },
                       })
                       .then((result) => {

--- a/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
+++ b/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
@@ -164,7 +164,7 @@ function QuestionaryComponentSampleDeclaration(
                   );
                 }
 
-                const proposalPk = state.proposal.id;
+                const proposalPk = state.proposal.primaryKey;
                 const questionId = props.answer.question.id;
                 if (proposalPk <= 0 || !questionId) {
                   throw new Error(
@@ -221,7 +221,7 @@ function QuestionaryComponentSampleDeclaration(
                       .getSamplesWithQuestionaryStatus({
                         filter: {
                           questionId: answer.question.id,
-                          proposalPk: state.proposal.id,
+                          proposalPk: state.proposal.primaryKey,
                         },
                       })
                       .then((result) => {

--- a/src/components/questionary/questionaryComponents/SampleDeclaration/SamplesAnswerRenderer.tsx
+++ b/src/components/questionary/questionaryComponents/SampleDeclaration/SamplesAnswerRenderer.tsx
@@ -43,18 +43,18 @@ function SampleList(props: {
 }
 
 interface SamplesAnswerRendererProps {
-  proposalId: number;
+  proposalPK: number;
   answer: Answer;
 }
 
 const SamplesAnswerRenderer = ({
-  proposalId,
+  proposalPK,
   answer,
 }: SamplesAnswerRendererProps) => {
   const [selectedSampleId, setSelectedSampleId] = useState<number | null>(null);
 
   const { samples } = useSamplesWithQuestionaryStatus({
-    proposalId: proposalId,
+    proposalPK: proposalPK,
     questionId: answer.question.id,
   });
 

--- a/src/components/questionary/questionaryComponents/SampleDeclaration/SamplesAnswerRenderer.tsx
+++ b/src/components/questionary/questionaryComponents/SampleDeclaration/SamplesAnswerRenderer.tsx
@@ -43,18 +43,18 @@ function SampleList(props: {
 }
 
 interface SamplesAnswerRendererProps {
-  proposalPK: number;
+  proposalPk: number;
   answer: Answer;
 }
 
 const SamplesAnswerRenderer = ({
-  proposalPK,
+  proposalPk,
   answer,
 }: SamplesAnswerRendererProps) => {
   const [selectedSampleId, setSelectedSampleId] = useState<number | null>(null);
 
   const { samples } = useSamplesWithQuestionaryStatus({
-    proposalPK: proposalPK,
+    proposalPk: proposalPk,
     questionId: answer.question.id,
   });
 

--- a/src/components/questionary/questionaryComponents/ShipmentBasis/QuestionaryComponentShipmentBasis.tsx
+++ b/src/components/questionary/questionaryComponents/ShipmentBasis/QuestionaryComponentShipmentBasis.tsx
@@ -119,7 +119,7 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
             data-cy="select-proposal-dropdown"
           >
             {proposals.map((proposal) => (
-              <MenuItem key={proposal.id} value={proposal.id}>
+              <MenuItem key={proposal.primaryKey} value={proposal.primaryKey}>
                 {proposal.title}
               </MenuItem>
             ))}

--- a/src/components/questionary/questionaryComponents/ShipmentBasis/QuestionaryComponentShipmentBasis.tsx
+++ b/src/components/questionary/questionaryComponents/ShipmentBasis/QuestionaryComponentShipmentBasis.tsx
@@ -60,8 +60,8 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
   ) as ShipmentContextType;
 
   const [title, setTitle] = useState(state?.shipment.title);
-  const [proposalPK, setProposalPK] = useState<number | null>(
-    state?.shipment.proposalPK || null
+  const [proposalPk, setProposalPk] = useState<number | null>(
+    state?.shipment.proposalPk || null
   );
   const [sampleIds, setSampleIds] = useState<number[]>(
     state?.shipment.samples.map((sample) => sample.id) || []
@@ -71,7 +71,7 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
   const { proposals, loadingProposals } = useUserProposals(
     currentRole as UserRole
   );
-  const { samples, loadingSamples } = useProposalSamples(proposalPK);
+  const { samples, loadingSamples } = useProposalSamples(proposalPk);
 
   if (!state || !dispatch) {
     throw new Error(createMissingContextErrorMessage());
@@ -109,12 +109,12 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
           <Select
             labelId="proposal-id"
             onChange={(event) => {
-              const newProposalPK = event.target.value as number;
-              setProposalPK(newProposalPK);
+              const newProposalPk = event.target.value as number;
+              setProposalPk(newProposalPk);
               setSampleIds([]);
-              handleChange({ proposalPK: newProposalPK });
+              handleChange({ proposalPk: newProposalPk });
             }}
-            value={proposalPK || ''}
+            value={proposalPk || ''}
             fullWidth
             data-cy="select-proposal-dropdown"
           >
@@ -124,7 +124,7 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
               </MenuItem>
             ))}
           </Select>
-          <ProposalErrorLabel>{fieldErrors?.proposalPK}</ProposalErrorLabel>
+          <ProposalErrorLabel>{fieldErrors?.proposalPk}</ProposalErrorLabel>
         </FormControl>
       )}
 
@@ -172,7 +172,7 @@ const shipmentBasisPreSubmit = () => async ({
     const result = await api.updateShipment({
       title: title,
       shipmentId: shipment.id,
-      proposalPK: shipment.proposalPK,
+      proposalPk: shipment.proposalPk,
     });
     if (result.updateShipment.shipment) {
       dispatch({
@@ -183,7 +183,7 @@ const shipmentBasisPreSubmit = () => async ({
   } else {
     const result = await api.createShipment({
       title: title,
-      proposalPK: shipment.proposalPK,
+      proposalPk: shipment.proposalPk,
     });
     if (result.createShipment.shipment) {
       dispatch({

--- a/src/components/questionary/questionaryComponents/ShipmentBasis/QuestionaryComponentShipmentBasis.tsx
+++ b/src/components/questionary/questionaryComponents/ShipmentBasis/QuestionaryComponentShipmentBasis.tsx
@@ -60,8 +60,8 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
   ) as ShipmentContextType;
 
   const [title, setTitle] = useState(state?.shipment.title);
-  const [proposalId, setProposalId] = useState<number | null>(
-    state?.shipment.proposalId || null
+  const [proposalPK, setProposalPK] = useState<number | null>(
+    state?.shipment.proposalPK || null
   );
   const [sampleIds, setSampleIds] = useState<number[]>(
     state?.shipment.samples.map((sample) => sample.id) || []
@@ -71,7 +71,7 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
   const { proposals, loadingProposals } = useUserProposals(
     currentRole as UserRole
   );
-  const { samples, loadingSamples } = useProposalSamples(proposalId);
+  const { samples, loadingSamples } = useProposalSamples(proposalPK);
 
   if (!state || !dispatch) {
     throw new Error(createMissingContextErrorMessage());
@@ -109,12 +109,12 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
           <Select
             labelId="proposal-id"
             onChange={(event) => {
-              const newProposalId = event.target.value as number;
-              setProposalId(newProposalId);
+              const newProposalPK = event.target.value as number;
+              setProposalPK(newProposalPK);
               setSampleIds([]);
-              handleChange({ proposalId: newProposalId });
+              handleChange({ proposalPK: newProposalPK });
             }}
-            value={proposalId || ''}
+            value={proposalPK || ''}
             fullWidth
             data-cy="select-proposal-dropdown"
           >
@@ -124,7 +124,7 @@ function QuestionaryComponentShipmentBasis(props: BasicComponentProps) {
               </MenuItem>
             ))}
           </Select>
-          <ProposalErrorLabel>{fieldErrors?.proposalId}</ProposalErrorLabel>
+          <ProposalErrorLabel>{fieldErrors?.proposalPK}</ProposalErrorLabel>
         </FormControl>
       )}
 
@@ -172,7 +172,7 @@ const shipmentBasisPreSubmit = () => async ({
     const result = await api.updateShipment({
       title: title,
       shipmentId: shipment.id,
-      proposalId: shipment.proposalId,
+      proposalPK: shipment.proposalPK,
     });
     if (result.updateShipment.shipment) {
       dispatch({
@@ -183,7 +183,7 @@ const shipmentBasisPreSubmit = () => async ({
   } else {
     const result = await api.createShipment({
       title: title,
-      proposalId: shipment.proposalId,
+      proposalPK: shipment.proposalPK,
     });
     if (result.createShipment.shipment) {
       dispatch({

--- a/src/components/questionary/questionaryComponents/ShipmentBasis/ShipmentBasisDefinition.tsx
+++ b/src/components/questionary/questionaryComponents/ShipmentBasis/ShipmentBasisDefinition.tsx
@@ -28,7 +28,7 @@ export const shipmentBasisDefinition: QuestionaryComponentDefinition = {
 
     return {
       title: shipmentState.shipment.title,
-      proposalPK: shipmentState.shipment.proposalPK,
+      proposalPk: shipmentState.shipment.proposalPk,
       samples: shipmentState.shipment.samples,
     };
   },

--- a/src/components/questionary/questionaryComponents/ShipmentBasis/ShipmentBasisDefinition.tsx
+++ b/src/components/questionary/questionaryComponents/ShipmentBasis/ShipmentBasisDefinition.tsx
@@ -28,7 +28,7 @@ export const shipmentBasisDefinition: QuestionaryComponentDefinition = {
 
     return {
       title: shipmentState.shipment.title,
-      proposalId: shipmentState.shipment.proposalId,
+      proposalPK: shipmentState.shipment.proposalPK,
       samples: shipmentState.shipment.samples,
     };
   },

--- a/src/components/questionary/questionaryComponents/ShipmentBasis/createShipmentBasisValidationSchema.ts
+++ b/src/components/questionary/questionaryComponents/ShipmentBasis/createShipmentBasisValidationSchema.ts
@@ -11,7 +11,7 @@ export const createShipmentBasisValidationSchema: QuestionaryComponentDefinition
         `Please make title at most ${MAX_TITLE_LEN} characters long`
       )
       .required('Title is required'),
-    proposalId: Yup.number().required('Proposal is required'),
+    proposalPK: Yup.number().required('Proposal is required'),
     samples: Yup.array().of(Yup.object()),
   });
 

--- a/src/components/questionary/questionaryComponents/ShipmentBasis/createShipmentBasisValidationSchema.ts
+++ b/src/components/questionary/questionaryComponents/ShipmentBasis/createShipmentBasisValidationSchema.ts
@@ -11,7 +11,7 @@ export const createShipmentBasisValidationSchema: QuestionaryComponentDefinition
         `Please make title at most ${MAX_TITLE_LEN} characters long`
       )
       .required('Title is required'),
-    proposalPK: Yup.number().required('Proposal is required'),
+    proposalPk: Yup.number().required('Proposal is required'),
     samples: Yup.array().of(Yup.object()),
   });
 

--- a/src/components/questionary/questionaryComponents/VisitBasis/QuestionaryComponentVisitBasis.tsx
+++ b/src/components/questionary/questionaryComponents/VisitBasis/QuestionaryComponentVisitBasis.tsx
@@ -42,7 +42,7 @@ function QuestionaryComponentVisitBasis(props: BasicComponentProps) {
   return (
     <>
       <FormikDropdown
-        name={`${questionId}.proposalId`}
+        name={`${questionId}.proposalPK`}
         label="Select proposal"
         loading={loadingProposals}
         noOptionsText="No proposals"
@@ -55,7 +55,7 @@ function QuestionaryComponentVisitBasis(props: BasicComponentProps) {
           dispatch({
             type: 'VISIT_MODIFIED',
             visit: {
-              proposalId: +event.target.value,
+              proposalPK: +event.target.value,
             },
           });
         }}
@@ -87,12 +87,12 @@ const visitBasisPreSubmit = () => async ({
   state,
 }: SubmitActionDependencyContainer) => {
   const visit = (state as VisitSubmissionState).visit;
-  const { proposalId, team } = visit;
+  const { proposalPK, team } = visit;
   let returnValue = state.questionaryId;
   if (visit.id > 0) {
     const result = await api.updateVisit({
       visitId: visit.id,
-      proposalId: visit.proposalId,
+      proposalPK: visit.proposalPK,
       team: visit.team.map((user) => user.id),
     });
 
@@ -104,7 +104,7 @@ const visitBasisPreSubmit = () => async ({
     }
   } else {
     const result = await api.createVisit({
-      proposalId: proposalId,
+      proposalPK: proposalPK,
       team: team.map((user) => user.id),
     });
 

--- a/src/components/questionary/questionaryComponents/VisitBasis/QuestionaryComponentVisitBasis.tsx
+++ b/src/components/questionary/questionaryComponents/VisitBasis/QuestionaryComponentVisitBasis.tsx
@@ -42,7 +42,7 @@ function QuestionaryComponentVisitBasis(props: BasicComponentProps) {
   return (
     <>
       <FormikDropdown
-        name={`${questionId}.proposalPK`}
+        name={`${questionId}.proposalPk`}
         label="Select proposal"
         loading={loadingProposals}
         noOptionsText="No proposals"
@@ -55,7 +55,7 @@ function QuestionaryComponentVisitBasis(props: BasicComponentProps) {
           dispatch({
             type: 'VISIT_MODIFIED',
             visit: {
-              proposalPK: +event.target.value,
+              proposalPk: +event.target.value,
             },
           });
         }}
@@ -87,12 +87,12 @@ const visitBasisPreSubmit = () => async ({
   state,
 }: SubmitActionDependencyContainer) => {
   const visit = (state as VisitSubmissionState).visit;
-  const { proposalPK, team } = visit;
+  const { proposalPk, team } = visit;
   let returnValue = state.questionaryId;
   if (visit.id > 0) {
     const result = await api.updateVisit({
       visitId: visit.id,
-      proposalPK: visit.proposalPK,
+      proposalPk: visit.proposalPk,
       team: visit.team.map((user) => user.id),
     });
 
@@ -104,7 +104,7 @@ const visitBasisPreSubmit = () => async ({
     }
   } else {
     const result = await api.createVisit({
-      proposalPK: proposalPK,
+      proposalPk: proposalPk,
       team: team.map((user) => user.id),
     });
 

--- a/src/components/questionary/questionaryComponents/VisitBasis/QuestionaryComponentVisitBasis.tsx
+++ b/src/components/questionary/questionaryComponents/VisitBasis/QuestionaryComponentVisitBasis.tsx
@@ -48,7 +48,7 @@ function QuestionaryComponentVisitBasis(props: BasicComponentProps) {
         noOptionsText="No proposals"
         items={proposals.map((proposal) => ({
           text: proposal.title,
-          value: proposal.id,
+          value: proposal.primaryKey,
         }))}
         InputProps={{ 'data-cy': 'proposal-selection' }}
         onChange={(event) => {

--- a/src/components/questionary/questionaryComponents/VisitBasis/createVisitBasisValidationSchema.ts
+++ b/src/components/questionary/questionaryComponents/VisitBasis/createVisitBasisValidationSchema.ts
@@ -4,7 +4,7 @@ import { CreateYupValidation } from 'components/questionary/QuestionaryComponent
 
 export const createVisitBasisValidationSchema: CreateYupValidation = () => {
   const schema = Yup.object().shape({
-    proposalPK: Yup.number().min(1, 'Proposal is required'),
+    proposalPk: Yup.number().min(1, 'Proposal is required'),
   });
 
   return schema;

--- a/src/components/questionary/questionaryComponents/VisitBasis/createVisitBasisValidationSchema.ts
+++ b/src/components/questionary/questionaryComponents/VisitBasis/createVisitBasisValidationSchema.ts
@@ -4,7 +4,7 @@ import { CreateYupValidation } from 'components/questionary/QuestionaryComponent
 
 export const createVisitBasisValidationSchema: CreateYupValidation = () => {
   const schema = Yup.object().shape({
-    proposalId: Yup.number().min(1, 'Proposal is required'),
+    proposalPK: Yup.number().min(1, 'Proposal is required'),
   });
 
   return schema;

--- a/src/components/review/AssignTechnicalReview.tsx
+++ b/src/components/review/AssignTechnicalReview.tsx
@@ -74,7 +74,7 @@ function AssignTechnicalReview({
                 )
                   .updateTechnicalReviewAssignee({
                     userId: selectedUser,
-                    proposalPKs: [proposal.id],
+                    proposalPks: [proposal.id],
                   })
                   .then((result) => {
                     onProposalUpdated({

--- a/src/components/review/AssignTechnicalReview.tsx
+++ b/src/components/review/AssignTechnicalReview.tsx
@@ -74,7 +74,7 @@ function AssignTechnicalReview({
                 )
                   .updateTechnicalReviewAssignee({
                     userId: selectedUser,
-                    proposalIds: [proposal.id],
+                    proposalPKs: [proposal.id],
                   })
                   .then((result) => {
                     onProposalUpdated({

--- a/src/components/review/AssignTechnicalReview.tsx
+++ b/src/components/review/AssignTechnicalReview.tsx
@@ -74,7 +74,7 @@ function AssignTechnicalReview({
                 )
                   .updateTechnicalReviewAssignee({
                     userId: selectedUser,
-                    proposalPks: [proposal.id],
+                    proposalPks: [proposal.primaryKey],
                   })
                   .then((result) => {
                     onProposalUpdated({

--- a/src/components/review/ProposalQuestionaryReview.tsx
+++ b/src/components/review/ProposalQuestionaryReview.tsx
@@ -42,7 +42,7 @@ export default function ProposalQuestionaryReview(
       questionaryId={data.questionaryId}
       additionalDetails={additionalDetails}
       title="Proposal information"
-      proposalPk={data.id}
+      proposalPk={data.primaryKey}
       {...restProps}
     />
   );

--- a/src/components/review/ProposalQuestionaryReview.tsx
+++ b/src/components/review/ProposalQuestionaryReview.tsx
@@ -42,7 +42,7 @@ export default function ProposalQuestionaryReview(
       questionaryId={data.questionaryId}
       additionalDetails={additionalDetails}
       title="Proposal information"
-      proposalId={data.id}
+      proposalPK={data.id}
       {...restProps}
     />
   );

--- a/src/components/review/ProposalQuestionaryReview.tsx
+++ b/src/components/review/ProposalQuestionaryReview.tsx
@@ -22,7 +22,7 @@ export default function ProposalQuestionaryReview(
   const users = data.users || [];
 
   const additionalDetails: TableRowData[] = [
-    { label: 'Proposal ID', value: data.shortCode },
+    { label: 'Proposal ID', value: data.proposalId },
     { label: 'Title', value: data.title },
     { label: 'Abstract', value: data.abstract },
     {

--- a/src/components/review/ProposalQuestionaryReview.tsx
+++ b/src/components/review/ProposalQuestionaryReview.tsx
@@ -42,7 +42,7 @@ export default function ProposalQuestionaryReview(
       questionaryId={data.questionaryId}
       additionalDetails={additionalDetails}
       title="Proposal information"
-      proposalPK={data.id}
+      proposalPk={data.id}
       {...restProps}
     />
   );

--- a/src/components/review/ProposalReviewContent.tsx
+++ b/src/components/review/ProposalReviewContent.tsx
@@ -38,7 +38,7 @@ export type TabNames =
 
 type ProposalReviewContentProps = {
   tabNames: TabNames[];
-  proposalPK?: number | null;
+  proposalPk?: number | null;
   reviewId?: number | null;
   sepId?: number | null;
   isInsideModal?: boolean;
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const ProposalReviewContent: React.FC<ProposalReviewContentProps> = ({
-  proposalPK,
+  proposalPk,
   tabNames,
   reviewId,
   sepId,
@@ -68,7 +68,7 @@ const ProposalReviewContent: React.FC<ProposalReviewContentProps> = ({
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
   const { reviewData, setReviewData } = useReviewData(reviewId, sepId);
   const { proposalData, setProposalData, loading } = useProposalData(
-    proposalPK || reviewData?.proposal?.id
+    proposalPk || reviewData?.proposal?.id
   );
 
   if (loading) {

--- a/src/components/review/ProposalReviewContent.tsx
+++ b/src/components/review/ProposalReviewContent.tsx
@@ -38,7 +38,7 @@ export type TabNames =
 
 type ProposalReviewContentProps = {
   tabNames: TabNames[];
-  proposalId?: number | null;
+  proposalPK?: number | null;
   reviewId?: number | null;
   sepId?: number | null;
   isInsideModal?: boolean;
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const ProposalReviewContent: React.FC<ProposalReviewContentProps> = ({
-  proposalId,
+  proposalPK,
   tabNames,
   reviewId,
   sepId,
@@ -68,7 +68,7 @@ const ProposalReviewContent: React.FC<ProposalReviewContentProps> = ({
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
   const { reviewData, setReviewData } = useReviewData(reviewId, sepId);
   const { proposalData, setProposalData, loading } = useProposalData(
-    proposalId || reviewData?.proposal?.id
+    proposalPK || reviewData?.proposal?.id
   );
 
   if (loading) {

--- a/src/components/review/ProposalReviewContent.tsx
+++ b/src/components/review/ProposalReviewContent.tsx
@@ -68,7 +68,7 @@ const ProposalReviewContent: React.FC<ProposalReviewContentProps> = ({
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
   const { reviewData, setReviewData } = useReviewData(reviewId, sepId);
   const { proposalData, setProposalData, loading } = useProposalData(
-    proposalPk || reviewData?.proposal?.id
+    proposalPk || reviewData?.proposal?.primaryKey
   );
 
   if (loading) {
@@ -183,7 +183,10 @@ const ProposalReviewContent: React.FC<ProposalReviewContentProps> = ({
   );
 
   const EventLogsTab = isUserOfficer && (
-    <EventLogList changedObjectId={proposalData.id} eventType="PROPOSAL" />
+    <EventLogList
+      changedObjectId={proposalData.primaryKey}
+      eventType="PROPOSAL"
+    />
   );
 
   const tabsContent = tabNames.map((tab, index) => {

--- a/src/components/review/ProposalReviewModal.tsx
+++ b/src/components/review/ProposalReviewModal.tsx
@@ -57,7 +57,7 @@ const ProposalReviewModal: React.FC<ProposalReviewModalProps> = ({
     }
 
     return api()
-      .getProposal({ id: reviewItemId })
+      .getProposal({ primaryKey: reviewItemId })
       .then((data) => {
         return data.proposal as Proposal;
       });

--- a/src/components/review/ProposalTableReviewer.tsx
+++ b/src/components/review/ProposalTableReviewer.tsx
@@ -37,7 +37,7 @@ import ReviewStatusFilter, {
 } from './ReviewStatusFilter';
 
 type UserWithReview = {
-  shortCode: string;
+  proposalId: string;
   proposalPk: number;
   title: string;
   grade: number;
@@ -124,7 +124,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
         ? userData.reviews.map(
             (review) =>
               ({
-                shortCode: review?.proposal?.shortCode,
+                proposalId: review?.proposal?.proposalId,
                 proposalPk: review?.proposal?.primaryKey,
                 title: review?.proposal?.title,
                 grade: review.grade,
@@ -223,7 +223,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
       sorting: false,
       render: RowActionButtons,
     },
-    { title: 'Proposal ID', field: 'shortCode' },
+    { title: 'Proposal ID', field: 'proposalId' },
     { title: 'Title', field: 'title' },
     { title: 'Grade', field: 'grade' },
     { title: 'Review status', field: 'status' },
@@ -338,7 +338,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
         }}
       />
       <ProposalReviewModal
-        title={`Review proposal: ${proposalToReview?.title} (${proposalToReview?.shortCode})`}
+        title={`Review proposal: ${proposalToReview?.title} (${proposalToReview?.proposalId})`}
         proposalReviewModalOpen={!!urlQueryParams.reviewModal}
         setProposalReviewModalOpen={() => {
           setUrlQueryParams({ reviewModal: undefined });

--- a/src/components/review/ProposalTableReviewer.tsx
+++ b/src/components/review/ProposalTableReviewer.tsx
@@ -125,7 +125,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
             (review) =>
               ({
                 shortCode: review?.proposal?.shortCode,
-                proposalPk: review?.proposal?.id,
+                proposalPk: review?.proposal?.primaryKey,
                 title: review?.proposal?.title,
                 grade: review.grade,
                 reviewId: review.id,

--- a/src/components/review/ProposalTableReviewer.tsx
+++ b/src/components/review/ProposalTableReviewer.tsx
@@ -13,7 +13,7 @@ import InstrumentFilter from 'components/common/proposalFilters/InstrumentFilter
 import { DefaultQueryParams } from 'components/common/SuperMaterialTable';
 import { ReviewAndAssignmentContext } from 'context/ReviewAndAssignmentContextProvider';
 import {
-  ProposalIdWithReviewId,
+  ProposalPKWithReviewId,
   ReviewerFilter,
   ReviewStatus,
   SepAssignment,
@@ -38,7 +38,7 @@ import ReviewStatusFilter, {
 
 type UserWithReview = {
   shortCode: string;
-  proposalId: number;
+  proposalPK: number;
   title: string;
   grade: number;
   reviewId: number;
@@ -76,7 +76,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
   });
 
   const [selectedProposals, setSelectedProposals] = useState<
-    (ProposalIdWithReviewId & { title: string })[]
+    (ProposalPKWithReviewId & { title: string })[]
   >([]);
 
   const [preselectedProposalsData, setPreselectedProposalsData] = useState<
@@ -125,7 +125,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
             (review) =>
               ({
                 shortCode: review?.proposal?.shortCode,
-                proposalId: review?.proposal?.id,
+                proposalPK: review?.proposal?.id,
                 title: review?.proposal?.title,
                 grade: review.grade,
                 reviewId: review.id,
@@ -145,14 +145,14 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
 
       setPreselectedProposalsData((preselectedProposalsData) => {
         const selected: {
-          proposalId: number;
+          proposalPK: number;
           reviewId: number;
           title: string;
         }[] = [];
         const preselected = preselectedProposalsData.map((proposal) => {
-          if (selection.has(proposal.proposalId.toString())) {
+          if (selection.has(proposal.proposalPK.toString())) {
             selected.push({
-              proposalId: proposal.proposalId,
+              proposalPK: proposal.proposalPK,
               reviewId: proposal.reviewId,
               title: proposal.title,
             });
@@ -161,7 +161,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
           return {
             ...proposal,
             tableData: {
-              checked: selection.has(proposal.proposalId.toString()),
+              checked: selection.has(proposal.proposalPK.toString()),
             },
           };
         });
@@ -200,7 +200,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
       <Tooltip title="Download Proposal">
         <IconButton
           onClick={() =>
-            downloadPDFProposal([rowData.proposalId], rowData.title)
+            downloadPDFProposal([rowData.proposalPK], rowData.title)
           }
         >
           <GetAppIcon />
@@ -259,7 +259,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
     if (selectedProposals?.length) {
       const shouldAddPluralLetter = selectedProposals.length > 1 ? 's' : '';
       const submitProposalReviewsInput = selectedProposals.map((proposal) => ({
-        proposalId: proposal.proposalId,
+        proposalPK: proposal.proposalPK,
         reviewId: proposal.reviewId,
       }));
 
@@ -366,7 +366,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
             selection:
               selectedItems.length > 0
                 ? selectedItems.map((selectedItem) =>
-                    selectedItem.proposalId.toString()
+                    selectedItem.proposalPK.toString()
                   )
                 : undefined,
           }));
@@ -382,7 +382,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
             tooltip: 'Download proposals',
             onClick: () => {
               downloadPDFProposal(
-                selectedProposals.map((proposal) => proposal.proposalId),
+                selectedProposals.map((proposal) => proposal.proposalPK),
                 selectedProposals[0].title
               );
             },

--- a/src/components/review/ProposalTableReviewer.tsx
+++ b/src/components/review/ProposalTableReviewer.tsx
@@ -13,7 +13,7 @@ import InstrumentFilter from 'components/common/proposalFilters/InstrumentFilter
 import { DefaultQueryParams } from 'components/common/SuperMaterialTable';
 import { ReviewAndAssignmentContext } from 'context/ReviewAndAssignmentContextProvider';
 import {
-  ProposalPKWithReviewId,
+  ProposalPkWithReviewId,
   ReviewerFilter,
   ReviewStatus,
   SepAssignment,
@@ -38,7 +38,7 @@ import ReviewStatusFilter, {
 
 type UserWithReview = {
   shortCode: string;
-  proposalPK: number;
+  proposalPk: number;
   title: string;
   grade: number;
   reviewId: number;
@@ -76,7 +76,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
   });
 
   const [selectedProposals, setSelectedProposals] = useState<
-    (ProposalPKWithReviewId & { title: string })[]
+    (ProposalPkWithReviewId & { title: string })[]
   >([]);
 
   const [preselectedProposalsData, setPreselectedProposalsData] = useState<
@@ -125,7 +125,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
             (review) =>
               ({
                 shortCode: review?.proposal?.shortCode,
-                proposalPK: review?.proposal?.id,
+                proposalPk: review?.proposal?.id,
                 title: review?.proposal?.title,
                 grade: review.grade,
                 reviewId: review.id,
@@ -145,14 +145,14 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
 
       setPreselectedProposalsData((preselectedProposalsData) => {
         const selected: {
-          proposalPK: number;
+          proposalPk: number;
           reviewId: number;
           title: string;
         }[] = [];
         const preselected = preselectedProposalsData.map((proposal) => {
-          if (selection.has(proposal.proposalPK.toString())) {
+          if (selection.has(proposal.proposalPk.toString())) {
             selected.push({
-              proposalPK: proposal.proposalPK,
+              proposalPk: proposal.proposalPk,
               reviewId: proposal.reviewId,
               title: proposal.title,
             });
@@ -161,7 +161,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
           return {
             ...proposal,
             tableData: {
-              checked: selection.has(proposal.proposalPK.toString()),
+              checked: selection.has(proposal.proposalPk.toString()),
             },
           };
         });
@@ -200,7 +200,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
       <Tooltip title="Download Proposal">
         <IconButton
           onClick={() =>
-            downloadPDFProposal([rowData.proposalPK], rowData.title)
+            downloadPDFProposal([rowData.proposalPk], rowData.title)
           }
         >
           <GetAppIcon />
@@ -259,7 +259,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
     if (selectedProposals?.length) {
       const shouldAddPluralLetter = selectedProposals.length > 1 ? 's' : '';
       const submitProposalReviewsInput = selectedProposals.map((proposal) => ({
-        proposalPK: proposal.proposalPK,
+        proposalPk: proposal.proposalPk,
         reviewId: proposal.reviewId,
       }));
 
@@ -366,7 +366,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
             selection:
               selectedItems.length > 0
                 ? selectedItems.map((selectedItem) =>
-                    selectedItem.proposalPK.toString()
+                    selectedItem.proposalPk.toString()
                   )
                 : undefined,
           }));
@@ -382,7 +382,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
             tooltip: 'Download proposals',
             onClick: () => {
               downloadPDFProposal(
-                selectedProposals.map((proposal) => proposal.proposalPK),
+                selectedProposals.map((proposal) => proposal.proposalPk),
                 selectedProposals[0].title
               );
             },

--- a/src/components/review/ProposalTechnicalReview.tsx
+++ b/src/components/review/ProposalTechnicalReview.tsx
@@ -89,7 +89,7 @@ const ProposalTechnicalReview = ({
         } successfully!`;
 
     const result = await api(successMessage)[method]({
-      proposalPK: proposal.id,
+      proposalPk: proposal.id,
       timeAllocation: +values.timeAllocation,
       comment: values.comment,
       publicComment: values.publicComment,
@@ -101,7 +101,7 @@ const ProposalTechnicalReview = ({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (!(result as any)[method].error) {
       setReview({
-        proposalPK: data?.proposalPK,
+        proposalPk: data?.proposalPk,
         timeAllocation: +values.timeAllocation,
         comment: values.comment,
         publicComment: values.publicComment,

--- a/src/components/review/ProposalTechnicalReview.tsx
+++ b/src/components/review/ProposalTechnicalReview.tsx
@@ -89,7 +89,7 @@ const ProposalTechnicalReview = ({
         } successfully!`;
 
     const result = await api(successMessage)[method]({
-      proposalID: proposal.id,
+      proposalPK: proposal.id,
       timeAllocation: +values.timeAllocation,
       comment: values.comment,
       publicComment: values.publicComment,
@@ -101,7 +101,7 @@ const ProposalTechnicalReview = ({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (!(result as any)[method].error) {
       setReview({
-        proposalID: data?.proposalID,
+        proposalPK: data?.proposalPK,
         timeAllocation: +values.timeAllocation,
         comment: values.comment,
         publicComment: values.publicComment,

--- a/src/components/review/ProposalTechnicalReview.tsx
+++ b/src/components/review/ProposalTechnicalReview.tsx
@@ -89,7 +89,7 @@ const ProposalTechnicalReview = ({
         } successfully!`;
 
     const result = await api(successMessage)[method]({
-      proposalPk: proposal.id,
+      proposalPk: proposal.primaryKey,
       timeAllocation: +values.timeAllocation,
       comment: values.comment,
       publicComment: values.publicComment,

--- a/src/components/sample/SampleSafetyPage.tsx
+++ b/src/components/sample/SampleSafetyPage.tsx
@@ -221,7 +221,7 @@ function SampleSafetyPage() {
     },
     {
       title: 'Proposal ID',
-      field: 'proposal.shortCode',
+      field: 'proposal.proposalId',
     },
     { title: 'Title', field: 'title' },
     { title: 'Status', field: 'safetyStatus' },

--- a/src/components/shipments/CreateShipment.tsx
+++ b/src/components/shipments/CreateShipment.tsx
@@ -37,7 +37,7 @@ function createShipmentStub(
       steps: questionarySteps,
     },
     proposal: {
-      shortCode: '123456',
+      proposalId: '123456',
     },
     samples: [],
   };

--- a/src/components/shipments/CreateShipment.tsx
+++ b/src/components/shipments/CreateShipment.tsx
@@ -29,7 +29,7 @@ function createShipmentStub(
     questionaryId: 0,
     created: new Date(),
     creatorId: creator.id,
-    proposalId: 0,
+    proposalPK: 0,
     questionary: {
       questionaryId: 0,
       templateId: templateId,

--- a/src/components/shipments/CreateShipment.tsx
+++ b/src/components/shipments/CreateShipment.tsx
@@ -29,7 +29,7 @@ function createShipmentStub(
     questionaryId: 0,
     created: new Date(),
     creatorId: creator.id,
-    proposalPK: 0,
+    proposalPk: 0,
     questionary: {
       questionaryId: 0,
       templateId: templateId,

--- a/src/components/shipments/ShipmentReview.tsx
+++ b/src/components/shipments/ShipmentReview.tsx
@@ -56,7 +56,7 @@ function ShipmentReview({ confirm }: ShipmentReviewProps) {
     {
       label: 'Proposal',
       value: (
-        <Link href={`/ProposalEdit/${proposalData.id}`}>
+        <Link href={`/ProposalEdit/${proposalData.primaryKey}`}>
           {proposalData.title}
         </Link>
       ),

--- a/src/components/shipments/ShipmentReview.tsx
+++ b/src/components/shipments/ShipmentReview.tsx
@@ -61,7 +61,7 @@ function ShipmentReview({ confirm }: ShipmentReviewProps) {
         </Link>
       ),
     },
-    { label: 'Proposal ID', value: state.shipment.proposal.shortCode },
+    { label: 'Proposal ID', value: state.shipment.proposal.proposalId },
     {
       label: 'Samples',
       value: (

--- a/src/components/shipments/ShipmentReview.tsx
+++ b/src/components/shipments/ShipmentReview.tsx
@@ -42,7 +42,7 @@ function ShipmentReview({ confirm }: ShipmentReviewProps) {
     throw new Error(createMissingContextErrorMessage());
   }
 
-  const { proposalData } = useProposalData(state.shipment.proposalId);
+  const { proposalData } = useProposalData(state.shipment.proposalPK);
   const downloadShipmentLabel = useDownloadPDFShipmentLabel();
   const classes = useStyles();
 

--- a/src/components/shipments/ShipmentReview.tsx
+++ b/src/components/shipments/ShipmentReview.tsx
@@ -42,7 +42,7 @@ function ShipmentReview({ confirm }: ShipmentReviewProps) {
     throw new Error(createMissingContextErrorMessage());
   }
 
-  const { proposalData } = useProposalData(state.shipment.proposalPK);
+  const { proposalData } = useProposalData(state.shipment.proposalPk);
   const downloadShipmentLabel = useDownloadPDFShipmentLabel();
   const classes = useStyles();
 

--- a/src/components/shipments/ShipmentsTable.tsx
+++ b/src/components/shipments/ShipmentsTable.tsx
@@ -37,7 +37,7 @@ const ShipmentsTable = (props: { confirm: WithConfirmType }) => {
   const columns = [
     {
       title: 'Proposal ID',
-      field: 'proposal.shortCode',
+      field: 'proposal.proposalId',
     },
     { title: 'Title', field: 'title' },
     { title: 'Status', field: 'status' },

--- a/src/components/template/AnswerCountDetails.tsx
+++ b/src/components/template/AnswerCountDetails.tsx
@@ -20,7 +20,7 @@ function ProposalList({ question }: { question: QuestionWithUsage }) {
       style={{ width: '100%' }}
       icons={tableIcons}
       columns={[
-        { title: 'Shortcode', field: 'shortCode' },
+        { title: 'ID', field: 'proposalId' },
         { title: 'Title', field: 'title' },
       ]}
       data={proposalsData}

--- a/src/components/visit/CreateVisit.tsx
+++ b/src/components/visit/CreateVisit.tsx
@@ -33,7 +33,7 @@ function createVisitStub(
     },
     team: [],
     proposal: {
-      id: 0,
+      primaryKey: 0,
       title: '',
       abstract: '',
       statusId: 0,

--- a/src/components/visit/CreateVisit.tsx
+++ b/src/components/visit/CreateVisit.tsx
@@ -24,7 +24,7 @@ function createVisitStub(
     status: VisitStatus.DRAFT,
     questionaryId: 0,
     visitorId: visitorId,
-    proposalPK: 0,
+    proposalPk: 0,
     questionary: {
       questionaryId: 0,
       templateId: templateId,

--- a/src/components/visit/CreateVisit.tsx
+++ b/src/components/visit/CreateVisit.tsx
@@ -24,7 +24,7 @@ function createVisitStub(
     status: VisitStatus.DRAFT,
     questionaryId: 0,
     visitorId: visitorId,
-    proposalId: 0,
+    proposalPK: 0,
     questionary: {
       questionaryId: 0,
       templateId: templateId,

--- a/src/components/visit/CreateVisit.tsx
+++ b/src/components/visit/CreateVisit.tsx
@@ -38,7 +38,7 @@ function createVisitStub(
       abstract: '',
       statusId: 0,
       publicStatus: ProposalPublicStatus.UNKNOWN,
-      shortCode: '',
+      proposalId: '',
       finalStatus: ProposalEndStatus.UNSET,
       commentForUser: '',
       commentForManagement: '',

--- a/src/components/visit/VisitReview.tsx
+++ b/src/components/visit/VisitReview.tsx
@@ -52,7 +52,7 @@ function VisitReview({ confirm }: VisitReviewProps) {
     {
       label: 'Proposal',
       value: (
-        <Link href={`/ProposalEdit/${proposalData.id}`}>
+        <Link href={`/ProposalEdit/${proposalData.primaryKey}`}>
           {proposalData.title}
         </Link>
       ),

--- a/src/components/visit/VisitReview.tsx
+++ b/src/components/visit/VisitReview.tsx
@@ -40,7 +40,7 @@ function VisitReview({ confirm }: VisitReviewProps) {
     throw new Error(createMissingContextErrorMessage());
   }
 
-  const { proposalData } = useProposalData(state.visit.proposalPK);
+  const { proposalData } = useProposalData(state.visit.proposalPk);
   const classes = useStyles();
 
   if (!proposalData) {

--- a/src/components/visit/VisitReview.tsx
+++ b/src/components/visit/VisitReview.tsx
@@ -40,7 +40,7 @@ function VisitReview({ confirm }: VisitReviewProps) {
     throw new Error(createMissingContextErrorMessage());
   }
 
-  const { proposalData } = useProposalData(state.visit.proposalId);
+  const { proposalData } = useProposalData(state.visit.proposalPK);
   const classes = useStyles();
 
   if (!proposalData) {

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -856,7 +856,7 @@ export type MutationSubmitInstrumentArgs = {
 
 
 export type MutationAdministrationProposalArgs = {
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   commentForUser?: Maybe<Scalars['String']>;
   commentForManagement?: Maybe<Scalars['String']>;
   finalStatus?: Maybe<ProposalEndStatus>;
@@ -1587,7 +1587,7 @@ export type PrepareDbResponseWrap = {
 
 export type Proposal = {
   __typename?: 'Proposal';
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   title: Scalars['String'];
   abstract: Scalars['String'];
   statusId: Scalars['Int'];
@@ -1685,7 +1685,7 @@ export type ProposalEvent = {
 };
 
 export type ProposalPkWithCallId = {
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   callId: Scalars['Int'];
 };
 
@@ -1758,7 +1758,7 @@ export type ProposalTemplatesFilter = {
 
 export type ProposalView = {
   __typename?: 'ProposalView';
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   title: Scalars['String'];
   statusId: Scalars['Int'];
   statusName: Scalars['String'];
@@ -3268,7 +3268,7 @@ export type GetSepProposalsQuery = (
     & Pick<SepProposal, 'proposalPk' | 'dateAssigned' | 'sepId' | 'sepTimeAllocation'>
     & { proposal: (
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'title' | 'id' | 'shortCode'>
+      & Pick<Proposal, 'title' | 'primaryKey' | 'shortCode'>
       & { status: Maybe<(
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
@@ -3304,7 +3304,7 @@ export type SepProposalsByInstrumentQuery = (
     & Pick<SepProposal, 'sepTimeAllocation'>
     & { proposal: (
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'title' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
       & { status: Maybe<(
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
@@ -4209,7 +4209,7 @@ export type UpdateInstrumentMutation = (
 );
 
 export type AdministrationProposalMutationVariables = Exact<{
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   finalStatus?: Maybe<ProposalEndStatus>;
   statusId?: Maybe<Scalars['Int']>;
   commentForUser?: Maybe<Scalars['String']>;
@@ -4225,7 +4225,7 @@ export type AdministrationProposalMutation = (
     { __typename?: 'ProposalResponseWrap' }
     & { proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id'>
+      & Pick<Proposal, 'primaryKey'>
     )>, rejection: Maybe<(
       { __typename?: 'Rejection' }
       & RejectionFragment
@@ -4308,7 +4308,7 @@ export type CreateProposalMutation = (
     { __typename?: 'ProposalResponseWrap' }
     & { proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'shortCode' | 'questionaryId'>
+      & Pick<Proposal, 'primaryKey' | 'shortCode' | 'questionaryId'>
       & { status: Maybe<(
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
@@ -4351,7 +4351,7 @@ export type DeleteProposalMutation = (
       & RejectionFragment
     )>, proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id'>
+      & Pick<Proposal, 'primaryKey'>
     )> }
   ) }
 );
@@ -4363,7 +4363,7 @@ export type CoreTechnicalReviewFragment = (
 
 export type ProposalFragment = (
   { __typename?: 'Proposal' }
-  & Pick<Proposal, 'id' | 'title' | 'abstract' | 'statusId' | 'publicStatus' | 'shortCode' | 'finalStatus' | 'commentForUser' | 'commentForManagement' | 'created' | 'updated' | 'callId' | 'questionaryId' | 'notified' | 'submitted' | 'managementTimeAllocation' | 'managementDecisionSubmitted' | 'technicalReviewAssignee'>
+  & Pick<Proposal, 'primaryKey' | 'title' | 'abstract' | 'statusId' | 'publicStatus' | 'shortCode' | 'finalStatus' | 'commentForUser' | 'commentForManagement' | 'created' | 'updated' | 'callId' | 'questionaryId' | 'notified' | 'submitted' | 'managementTimeAllocation' | 'managementDecisionSubmitted' | 'technicalReviewAssignee'>
   & { status: Maybe<(
     { __typename?: 'ProposalStatus' }
     & ProposalStatusFragment
@@ -4542,7 +4542,7 @@ export type GetProposalsCoreQuery = (
   { __typename?: 'Query' }
   & { proposalsView: Maybe<Array<(
     { __typename?: 'ProposalView' }
-    & Pick<ProposalView, 'id' | 'title' | 'statusId' | 'statusName' | 'statusDescription' | 'shortCode' | 'rankOrder' | 'finalStatus' | 'notified' | 'timeAllocation' | 'technicalStatus' | 'instrumentName' | 'callShortCode' | 'sepCode' | 'sepId' | 'reviewAverage' | 'reviewDeviation' | 'instrumentId' | 'callId' | 'submitted' | 'allocationTimeUnit'>
+    & Pick<ProposalView, 'primaryKey' | 'title' | 'statusId' | 'statusName' | 'statusDescription' | 'shortCode' | 'rankOrder' | 'finalStatus' | 'notified' | 'timeAllocation' | 'technicalStatus' | 'instrumentName' | 'callShortCode' | 'sepCode' | 'sepId' | 'reviewAverage' | 'reviewDeviation' | 'instrumentId' | 'callId' | 'submitted' | 'allocationTimeUnit'>
   )>> }
 );
 
@@ -4557,7 +4557,7 @@ export type NotifyProposalMutation = (
     { __typename?: 'ProposalResponseWrap' }
     & { proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id'>
+      & Pick<Proposal, 'primaryKey'>
     )>, rejection: Maybe<(
       { __typename?: 'Rejection' }
       & RejectionFragment
@@ -4599,7 +4599,7 @@ export type UpdateProposalMutation = (
     { __typename?: 'ProposalResponseWrap' }
     & { proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'title' | 'abstract'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'abstract'>
       & { proposer: Maybe<(
         { __typename?: 'BasicUserDetails' }
         & BasicUserDetailsFragment
@@ -4627,7 +4627,7 @@ export type GetUserProposalBookingsWithEventsQuery = (
     { __typename?: 'User' }
     & { proposals: Array<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'title' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
       & { proposalBooking: Maybe<(
         { __typename?: 'ProposalBooking' }
         & { scheduledEvents: Array<(
@@ -4897,7 +4897,7 @@ export type GetReviewQuery = (
     { __typename?: 'Review' }
     & { proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'title' | 'abstract'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'abstract'>
       & { proposer: Maybe<(
         { __typename?: 'BasicUserDetails' }
         & Pick<BasicUserDetails, 'id'>
@@ -5014,7 +5014,7 @@ export type UserWithReviewsQuery = (
       & Pick<Review, 'id' | 'grade' | 'comment' | 'status' | 'sepID'>
       & { proposal: Maybe<(
         { __typename?: 'Proposal' }
-        & Pick<Proposal, 'id' | 'title' | 'shortCode'>
+        & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
         & { call: Maybe<(
           { __typename?: 'Call' }
           & Pick<Call, 'shortCode'>
@@ -5131,7 +5131,7 @@ export type GetSamplesByCallIdQuery = (
     { __typename?: 'Sample' }
     & { proposal: (
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'shortCode'>
     ) }
     & SampleFragment
   )>> }
@@ -5148,7 +5148,7 @@ export type GetSamplesWithProposalDataQuery = (
     { __typename?: 'Sample' }
     & { proposal: (
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'shortCode'>
     ) }
     & SampleFragment
   )>> }
@@ -6563,7 +6563,7 @@ export type GetUserProposalsQuery = (
     { __typename?: 'User' }
     & { proposals: Array<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'shortCode' | 'title' | 'publicStatus' | 'statusId' | 'created' | 'finalStatus' | 'notified' | 'submitted'>
+      & Pick<Proposal, 'primaryKey' | 'shortCode' | 'title' | 'publicStatus' | 'statusId' | 'created' | 'finalStatus' | 'notified' | 'submitted'>
       & { status: Maybe<(
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
@@ -7056,7 +7056,7 @@ export const SepMeetingDecisionFragmentDoc = gql`
     `;
 export const ProposalFragmentDoc = gql`
     fragment proposal on Proposal {
-  id
+  primaryKey
   title
   abstract
   statusId
@@ -7597,7 +7597,7 @@ export const GetSepProposalsDocument = gql`
     sepTimeAllocation
     proposal {
       title
-      id
+      primaryKey
       shortCode
       status {
         ...proposalStatus
@@ -7635,7 +7635,7 @@ export const SepProposalsByInstrumentDocument = gql`
   ) {
     sepTimeAllocation
     proposal {
-      id
+      primaryKey
       title
       shortCode
       status {
@@ -8270,9 +8270,9 @@ export const UpdateInstrumentDocument = gql`
     ${BasicUserDetailsFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const AdministrationProposalDocument = gql`
-    mutation administrationProposal($id: Int!, $finalStatus: ProposalEndStatus, $statusId: Int, $commentForUser: String, $commentForManagement: String, $managementTimeAllocation: Int, $managementDecisionSubmitted: Boolean) {
+    mutation administrationProposal($primaryKey: Int!, $finalStatus: ProposalEndStatus, $statusId: Int, $commentForUser: String, $commentForManagement: String, $managementTimeAllocation: Int, $managementDecisionSubmitted: Boolean) {
   administrationProposal(
-    id: $id
+    primaryKey: $primaryKey
     finalStatus: $finalStatus
     statusId: $statusId
     commentForUser: $commentForUser
@@ -8281,7 +8281,7 @@ export const AdministrationProposalDocument = gql`
     managementDecisionSubmitted: $managementDecisionSubmitted
   ) {
     proposal {
-      id
+      primaryKey
     }
     rejection {
       ...rejection
@@ -8358,7 +8358,7 @@ export const CreateProposalDocument = gql`
     mutation createProposal($callId: Int!) {
   createProposal(callId: $callId) {
     proposal {
-      id
+      primaryKey
       status {
         ...proposalStatus
       }
@@ -8398,7 +8398,7 @@ export const DeleteProposalDocument = gql`
       ...rejection
     }
     proposal {
-      id
+      primaryKey
     }
   }
 }
@@ -8572,7 +8572,7 @@ ${CoreTechnicalReviewFragmentDoc}`;
 export const GetProposalsCoreDocument = gql`
     query getProposalsCore($filter: ProposalsFilter) {
   proposalsView(filter: $filter) {
-    id
+    primaryKey
     title
     statusId
     statusName
@@ -8600,7 +8600,7 @@ export const NotifyProposalDocument = gql`
     mutation notifyProposal($id: Int!) {
   notifyProposal(id: $id) {
     proposal {
-      id
+      primaryKey
     }
     rejection {
       ...rejection
@@ -8631,7 +8631,7 @@ export const UpdateProposalDocument = gql`
     proposerId: $proposerId
   ) {
     proposal {
-      id
+      primaryKey
       title
       abstract
       proposer {
@@ -8652,7 +8652,7 @@ export const GetUserProposalBookingsWithEventsDocument = gql`
     query getUserProposalBookingsWithEvents($endsAfter: TzLessDateTime, $status: [ProposalBookingStatus!], $instrumentId: Int) {
   me {
     proposals(filter: {instrumentId: $instrumentId}) {
-      id
+      primaryKey
       title
       shortCode
       proposalBooking(filter: {status: $status}) {
@@ -8781,7 +8781,7 @@ export const GetReviewDocument = gql`
   review(reviewId: $reviewId, sepId: $sepId) {
     ...coreReview
     proposal {
-      id
+      primaryKey
       title
       abstract
       proposer {
@@ -8875,7 +8875,7 @@ export const UserWithReviewsDocument = gql`
       status
       sepID
       proposal {
-        id
+        primaryKey
         title
         shortCode
         call {
@@ -8960,7 +8960,7 @@ export const GetSamplesByCallIdDocument = gql`
   samplesByCallId(callId: $callId) {
     ...sample
     proposal {
-      id
+      primaryKey
       shortCode
     }
   }
@@ -8971,7 +8971,7 @@ export const GetSamplesWithProposalDataDocument = gql`
   samples(filter: $filter) {
     ...sample
     proposal {
-      id
+      primaryKey
       shortCode
     }
   }
@@ -9846,7 +9846,7 @@ export const GetUserProposalsDocument = gql`
     query getUserProposals {
   me {
     proposals {
-      id
+      primaryKey
       shortCode
       title
       status {

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -872,7 +872,7 @@ export type MutationCloneProposalArgs = {
 
 
 export type MutationUpdateProposalArgs = {
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
   abstract?: Maybe<Scalars['String']>;
   users?: Maybe<Array<Scalars['Int']>>;
@@ -4585,7 +4585,7 @@ export type SubmitProposalMutation = (
 );
 
 export type UpdateProposalMutationVariables = Exact<{
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
   abstract?: Maybe<Scalars['String']>;
   users?: Maybe<Array<Scalars['Int']> | Scalars['Int']>;
@@ -8622,9 +8622,9 @@ export const SubmitProposalDocument = gql`
     ${ProposalFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const UpdateProposalDocument = gql`
-    mutation updateProposal($id: Int!, $title: String, $abstract: String, $users: [Int!], $proposerId: Int) {
+    mutation updateProposal($primaryKey: Int!, $title: String, $abstract: String, $users: [Int!], $proposerId: Int) {
   updateProposal(
-    id: $id
+    primaryKey: $primaryKey
     title: $title
     abstract: $abstract
     users: $users

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -2067,7 +2067,7 @@ export type QueryIsNaturalKeyPresentArgs = {
 
 
 export type QueryProposalArgs = {
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
 };
 
 
@@ -4433,7 +4433,7 @@ export type GetMyProposalsQuery = (
 );
 
 export type GetProposalQueryVariables = Exact<{
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
 }>;
 
 
@@ -8460,8 +8460,8 @@ export const GetMyProposalsDocument = gql`
 }
     ${ProposalFragmentDoc}`;
 export const GetProposalDocument = gql`
-    query getProposal($id: Int!) {
-  proposal(id: $id) {
+    query getProposal($primaryKey: Int!) {
+  proposal(primaryKey: $primaryKey) {
     ...proposal
     proposer {
       ...basicUserDetails

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -35,7 +35,7 @@ export type AddStatusChangingEventsToConnectionInput = {
 };
 
 export type AddTechnicalReviewInput = {
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
   timeAllocation?: Maybe<Scalars['Int']>;
@@ -193,7 +193,7 @@ export type CallsFilter = {
 
 export type ChangeProposalsStatusInput = {
   statusId: Scalars['Int'];
-  proposals: Array<ProposalPKWithCallId>;
+  proposals: Array<ProposalPkWithCallId>;
 };
 
 export type CheckExternalTokenWrap = {
@@ -802,13 +802,13 @@ export type MutationChangeProposalsStatusArgs = {
 
 
 export type MutationAssignProposalsToInstrumentArgs = {
-  proposals: Array<ProposalPKWithCallId>;
+  proposals: Array<ProposalPkWithCallId>;
   instrumentId: Scalars['Int'];
 };
 
 
 export type MutationRemoveProposalsFromInstrumentArgs = {
-  proposalPKs: Array<Scalars['Int']>;
+  proposalPks: Array<Scalars['Int']>;
 };
 
 
@@ -950,7 +950,7 @@ export type MutationAddReviewArgs = {
 
 export type MutationAddUserForReviewArgs = {
   userID: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepID: Scalars['Int'];
 };
 
@@ -962,14 +962,14 @@ export type MutationSubmitProposalsReviewArgs = {
 
 export type MutationUpdateTechnicalReviewAssigneeArgs = {
   userId: Scalars['Int'];
-  proposalPKs: Array<Scalars['Int']>;
+  proposalPks: Array<Scalars['Int']>;
 };
 
 
 export type MutationCreateSampleArgs = {
   title: Scalars['String'];
   templateId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   questionId: Scalars['String'];
 };
 
@@ -1003,25 +1003,25 @@ export type MutationRemoveMemberFromSepArgs = {
 export type MutationAssignSepReviewersToProposalArgs = {
   memberIds: Array<Scalars['Int']>;
   sepId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
 export type MutationRemoveMemberFromSepProposalArgs = {
   memberId: Scalars['Int'];
   sepId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
 export type MutationAssignProposalsToSepArgs = {
-  proposals: Array<ProposalPKWithCallId>;
+  proposals: Array<ProposalPkWithCallId>;
   sepId: Scalars['Int'];
 };
 
 
 export type MutationRemoveProposalsFromSepArgs = {
-  proposalPKs: Array<Scalars['Int']>;
+  proposalPks: Array<Scalars['Int']>;
   sepId: Scalars['Int'];
 };
 
@@ -1055,20 +1055,20 @@ export type MutationUpdateSepArgs = {
 
 export type MutationUpdateSepTimeAllocationArgs = {
   sepId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepTimeAllocation?: Maybe<Scalars['Int']>;
 };
 
 
 export type MutationCreateShipmentArgs = {
   title: Scalars['String'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
 export type MutationUpdateShipmentArgs = {
   shipmentId: Scalars['Int'];
-  proposalPK?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   status?: Maybe<ShipmentStatus>;
   externalRef?: Maybe<Scalars['String']>;
@@ -1272,7 +1272,7 @@ export type MutationCreateProposalArgs = {
 
 
 export type MutationCreateVisitArgs = {
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   team?: Maybe<Array<Scalars['Int']>>;
 };
 
@@ -1436,7 +1436,7 @@ export type MutationUpdatePasswordArgs = {
 export type MutationUpdateVisitArgs = {
   visitId: Scalars['Int'];
   status?: Maybe<VisitStatus>;
-  proposalPK?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
   team?: Maybe<Array<Scalars['Int']>>;
 };
 
@@ -1684,18 +1684,18 @@ export type ProposalEvent = {
   description: Maybe<Scalars['String']>;
 };
 
-export type ProposalPKWithCallId = {
+export type ProposalPkWithCallId = {
   id: Scalars['Int'];
   callId: Scalars['Int'];
 };
 
-export type ProposalPKWithRankOrder = {
-  proposalPK: Scalars['Int'];
+export type ProposalPkWithRankOrder = {
+  proposalPk: Scalars['Int'];
   rankOrder: Scalars['Int'];
 };
 
-export type ProposalPKWithReviewId = {
-  proposalPK: Scalars['Int'];
+export type ProposalPkWithReviewId = {
+  proposalPk: Scalars['Int'];
   reviewId: Scalars['Int'];
 };
 
@@ -2056,7 +2056,7 @@ export type QueryInstrumentScientistHasInstrumentArgs = {
 
 
 export type QueryInstrumentScientistHasAccessArgs = {
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   instrumentId: Scalars['Int'];
 };
 
@@ -2072,7 +2072,7 @@ export type QueryProposalArgs = {
 
 
 export type QueryUserHasAccessToProposalArgs = {
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
@@ -2108,7 +2108,7 @@ export type QueryReviewArgs = {
 
 
 export type QueryProposalReviewsArgs = {
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
@@ -2149,7 +2149,7 @@ export type QuerySepProposalsArgs = {
 
 
 export type QuerySepProposalArgs = {
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepId: Scalars['Int'];
 };
 
@@ -2354,7 +2354,7 @@ export type RemoveAssignedInstrumentFromCallInput = {
 };
 
 export type ReorderSepMeetingDecisionProposalsInput = {
-  proposals: Array<ProposalPKWithRankOrder>;
+  proposals: Array<ProposalPkWithRankOrder>;
 };
 
 export type Review = {
@@ -2432,7 +2432,7 @@ export type Sep = {
 
 export type SepAssignment = {
   __typename?: 'SEPAssignment';
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepMemberUserId: Maybe<Scalars['Int']>;
   sepId: Scalars['Int'];
   dateAssigned: Scalars['DateTime'];
@@ -2447,7 +2447,7 @@ export type SepAssignment = {
 
 export type SepProposal = {
   __typename?: 'SEPProposal';
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepId: Scalars['Int'];
   dateAssigned: Scalars['DateTime'];
   sepTimeAllocation: Maybe<Scalars['Int']>;
@@ -2488,7 +2488,7 @@ export type Sample = {
   title: Scalars['String'];
   creatorId: Scalars['Int'];
   questionaryId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   questionId: Scalars['String'];
   safetyStatus: SampleStatus;
   safetyComment: Scalars['String'];
@@ -2522,11 +2522,11 @@ export type SamplesFilter = {
   sampleIds?: Maybe<Array<Scalars['Int']>>;
   status?: Maybe<SampleStatus>;
   questionId?: Maybe<Scalars['String']>;
-  proposalPK?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
 };
 
 export type SaveSepMeetingDecisionInput = {
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   commentForUser?: Maybe<Scalars['String']>;
   commentForManagement?: Maybe<Scalars['String']>;
   recommendation?: Maybe<ProposalEndStatus>;
@@ -2546,7 +2546,7 @@ export type ScheduledEvent = {
   scheduledBy: Maybe<User>;
   description: Maybe<Scalars['String']>;
   instrument: Maybe<Instrument>;
-  equipmentId: Scalars['Int'];
+  equipmentId: Maybe<Scalars['Int']>;
   equipments: Array<EquipmentWithAssignmentStatus>;
   equipmentAssignmentStatus: Maybe<EquipmentAssignmentStatus>;
   proposalBooking: Maybe<ProposalBooking>;
@@ -2595,7 +2595,7 @@ export type SelectionFromOptionsConfig = {
 
 export type SepMeetingDecision = {
   __typename?: 'SepMeetingDecision';
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   recommendation: Maybe<ProposalEndStatus>;
   commentForManagement: Maybe<Scalars['String']>;
   commentForUser: Maybe<Scalars['String']>;
@@ -2625,7 +2625,7 @@ export type Shipment = {
   __typename?: 'Shipment';
   id: Scalars['Int'];
   title: Scalars['String'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   status: ShipmentStatus;
   externalRef: Maybe<Scalars['String']>;
   questionaryId: Scalars['Int'];
@@ -2657,7 +2657,7 @@ export enum ShipmentStatus {
 export type ShipmentsFilter = {
   title?: Maybe<Scalars['String']>;
   creatorId?: Maybe<Scalars['Int']>;
-  proposalPK?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
   questionaryIds?: Maybe<Array<Scalars['Int']>>;
   status?: Maybe<ShipmentStatus>;
   externalRef?: Maybe<Scalars['String']>;
@@ -2686,11 +2686,11 @@ export type StatusChangingEvent = {
 };
 
 export type SubmitProposalsReviewInput = {
-  proposals: Array<ProposalPKWithReviewId>;
+  proposals: Array<ProposalPkWithReviewId>;
 };
 
 export type SubmitTechnicalReviewInput = {
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
   timeAllocation?: Maybe<Scalars['Int']>;
@@ -2719,7 +2719,7 @@ export type SuccessResponseWrap = {
 export type TechnicalReview = {
   __typename?: 'TechnicalReview';
   id: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   comment: Maybe<Scalars['String']>;
   publicComment: Maybe<Scalars['String']>;
   timeAllocation: Maybe<Scalars['Int']>;
@@ -2961,7 +2961,7 @@ export enum UserRole {
 export type Visit = {
   __typename?: 'Visit';
   id: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   status: VisitStatus;
   questionaryId: Scalars['Int'];
   visitorId: Scalars['Int'];
@@ -2992,11 +2992,11 @@ export enum VisitStatus {
 export type VisitsFilter = {
   visitorId?: Maybe<Scalars['Int']>;
   questionaryId?: Maybe<Scalars['Int']>;
-  proposalPK?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
 };
 
 export type AssignProposalsToSepMutationVariables = Exact<{
-  proposals: Array<ProposalPKWithCallId> | ProposalPKWithCallId;
+  proposals: Array<ProposalPkWithCallId> | ProposalPkWithCallId;
   sepId: Scalars['Int'];
 }>;
 
@@ -3057,7 +3057,7 @@ export type AssignChairOrSecretaryMutation = (
 export type AssignSepReviewersToProposalMutationVariables = Exact<{
   memberIds: Array<Scalars['Int']> | Scalars['Int'];
   sepId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 }>;
 
 
@@ -3125,7 +3125,7 @@ export type DeleteSepMutation = (
 
 export type SepMeetingDecisionFragment = (
   { __typename?: 'SepMeetingDecision' }
-  & Pick<SepMeetingDecision, 'proposalPK' | 'recommendation' | 'commentForUser' | 'commentForManagement' | 'rankOrder' | 'submitted' | 'submittedBy'>
+  & Pick<SepMeetingDecision, 'proposalPk' | 'recommendation' | 'commentForUser' | 'commentForManagement' | 'rankOrder' | 'submitted' | 'submittedBy'>
 );
 
 export type GetInstrumentsBySepQueryVariables = Exact<{
@@ -3209,7 +3209,7 @@ export type GetSepMembersQuery = (
 
 export type GetSepProposalQueryVariables = Exact<{
   sepId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 }>;
 
 
@@ -3217,7 +3217,7 @@ export type GetSepProposalQuery = (
   { __typename?: 'Query' }
   & { sepProposal: Maybe<(
     { __typename?: 'SEPProposal' }
-    & Pick<SepProposal, 'proposalPK' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'>
+    & Pick<SepProposal, 'proposalPk' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'>
     & { proposal: (
       { __typename?: 'Proposal' }
       & { proposer: Maybe<(
@@ -3265,7 +3265,7 @@ export type GetSepProposalsQuery = (
   { __typename?: 'Query' }
   & { sepProposals: Maybe<Array<(
     { __typename?: 'SEPProposal' }
-    & Pick<SepProposal, 'proposalPK' | 'dateAssigned' | 'sepId' | 'sepTimeAllocation'>
+    & Pick<SepProposal, 'proposalPk' | 'dateAssigned' | 'sepId' | 'sepTimeAllocation'>
     & { proposal: (
       { __typename?: 'Proposal' }
       & Pick<Proposal, 'title' | 'id' | 'shortCode'>
@@ -3371,7 +3371,7 @@ export type GetSePsQuery = (
 );
 
 export type RemoveProposalsFromSepMutationVariables = Exact<{
-  proposalPKs: Array<Scalars['Int']> | Scalars['Int'];
+  proposalPks: Array<Scalars['Int']> | Scalars['Int'];
   sepId: Scalars['Int'];
 }>;
 
@@ -3414,7 +3414,7 @@ export type RemoveMemberFromSepMutation = (
 export type RemoveMemberFromSepProposalMutationVariables = Exact<{
   memberId: Scalars['Int'];
   sepId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 }>;
 
 
@@ -3446,7 +3446,7 @@ export type ReorderSepMeetingDecisionProposalsMutation = (
       & RejectionFragment
     )>, sepMeetingDecision: Maybe<(
       { __typename?: 'SepMeetingDecision' }
-      & Pick<SepMeetingDecision, 'proposalPK'>
+      & Pick<SepMeetingDecision, 'proposalPk'>
     )> }
   ) }
 );
@@ -3465,7 +3465,7 @@ export type SaveSepMeetingDecisionMutation = (
       & RejectionFragment
     )>, sepMeetingDecision: Maybe<(
       { __typename?: 'SepMeetingDecision' }
-      & Pick<SepMeetingDecision, 'proposalPK'>
+      & Pick<SepMeetingDecision, 'proposalPk'>
     )> }
   ) }
 );
@@ -3495,7 +3495,7 @@ export type UpdateSepMutation = (
 
 export type UpdateSepTimeAllocationMutationVariables = Exact<{
   sepId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepTimeAllocation?: Maybe<Scalars['Int']>;
 }>;
 
@@ -3992,7 +3992,7 @@ export type GetEventLogsQuery = (
 );
 
 export type AssignProposalsToInstrumentMutationVariables = Exact<{
-  proposals: Array<ProposalPKWithCallId> | ProposalPKWithCallId;
+  proposals: Array<ProposalPkWithCallId> | ProposalPkWithCallId;
   instrumentId: Scalars['Int'];
 }>;
 
@@ -4109,7 +4109,7 @@ export type GetUserInstrumentsQuery = (
 );
 
 export type RemoveProposalsFromInstrumentMutationVariables = Exact<{
-  proposalPKs: Array<Scalars['Int']> | Scalars['Int'];
+  proposalPks: Array<Scalars['Int']> | Scalars['Int'];
 }>;
 
 
@@ -4234,7 +4234,7 @@ export type AdministrationProposalMutation = (
 );
 
 export type ChangeProposalsStatusMutationVariables = Exact<{
-  proposals: Array<ProposalPKWithCallId> | ProposalPKWithCallId;
+  proposals: Array<ProposalPkWithCallId> | ProposalPkWithCallId;
   statusId: Scalars['Int'];
 }>;
 
@@ -4358,7 +4358,7 @@ export type DeleteProposalMutation = (
 
 export type CoreTechnicalReviewFragment = (
   { __typename?: 'TechnicalReview' }
-  & Pick<TechnicalReview, 'id' | 'comment' | 'publicComment' | 'timeAllocation' | 'status' | 'proposalPK' | 'submitted'>
+  & Pick<TechnicalReview, 'id' | 'comment' | 'publicComment' | 'timeAllocation' | 'status' | 'proposalPk' | 'submitted'>
 );
 
 export type ProposalFragment = (
@@ -4802,7 +4802,7 @@ export type GetQuestionaryQuery = (
 );
 
 export type AddTechnicalReviewMutationVariables = Exact<{
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   timeAllocation?: Maybe<Scalars['Int']>;
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
@@ -4828,7 +4828,7 @@ export type AddTechnicalReviewMutation = (
 
 export type AddUserForReviewMutationVariables = Exact<{
   userID: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepID: Scalars['Int'];
 }>;
 
@@ -4848,7 +4848,7 @@ export type AddUserForReviewMutation = (
 );
 
 export type UpdateTechnicalReviewAssigneeMutationVariables = Exact<{
-  proposalPKs: Array<Scalars['Int']> | Scalars['Int'];
+  proposalPks: Array<Scalars['Int']> | Scalars['Int'];
   userId: Scalars['Int'];
 }>;
 
@@ -4873,7 +4873,7 @@ export type CoreReviewFragment = (
 );
 
 export type GetProposalReviewsQueryVariables = Exact<{
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 }>;
 
 
@@ -4928,7 +4928,7 @@ export type RemoveUserForReviewMutation = (
 );
 
 export type SubmitProposalsReviewMutationVariables = Exact<{
-  proposals: Array<ProposalPKWithReviewId> | ProposalPKWithReviewId;
+  proposals: Array<ProposalPkWithReviewId> | ProposalPkWithReviewId;
 }>;
 
 
@@ -4945,7 +4945,7 @@ export type SubmitProposalsReviewMutation = (
 );
 
 export type SubmitTechnicalReviewMutationVariables = Exact<{
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   timeAllocation?: Maybe<Scalars['Int']>;
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
@@ -5054,7 +5054,7 @@ export type CloneSampleMutation = (
 export type CreateSampleMutationVariables = Exact<{
   title: Scalars['String'];
   templateId: Scalars['Int'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   questionId: Scalars['String'];
 }>;
 
@@ -5099,7 +5099,7 @@ export type DeleteSampleMutation = (
 
 export type SampleFragment = (
   { __typename?: 'Sample' }
-  & Pick<Sample, 'id' | 'title' | 'creatorId' | 'questionaryId' | 'safetyStatus' | 'safetyComment' | 'created' | 'proposalPK' | 'questionId'>
+  & Pick<Sample, 'id' | 'title' | 'creatorId' | 'questionaryId' | 'safetyStatus' | 'safetyComment' | 'created' | 'proposalPk' | 'questionId'>
 );
 
 export type GetSampleQueryVariables = Exact<{
@@ -5519,7 +5519,7 @@ export type AddSamplesToShipmentMutation = (
 
 export type CreateShipmentMutationVariables = Exact<{
   title: Scalars['String'];
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 }>;
 
 
@@ -5562,7 +5562,7 @@ export type DeleteShipmentMutation = (
 
 export type ShipmentFragment = (
   { __typename?: 'Shipment' }
-  & Pick<Shipment, 'id' | 'title' | 'proposalPK' | 'status' | 'externalRef' | 'questionaryId' | 'creatorId' | 'created'>
+  & Pick<Shipment, 'id' | 'title' | 'proposalPk' | 'status' | 'externalRef' | 'questionaryId' | 'creatorId' | 'created'>
   & { proposal: (
     { __typename?: 'Proposal' }
     & Pick<Proposal, 'shortCode'>
@@ -5653,7 +5653,7 @@ export type SubmitShipmentMutation = (
 export type UpdateShipmentMutationVariables = Exact<{
   shipmentId: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
-  proposalPK?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
   status?: Maybe<ShipmentStatus>;
 }>;
 
@@ -6806,7 +6806,7 @@ export type VerifyEmailMutation = (
 );
 
 export type CreateVisitMutationVariables = Exact<{
-  proposalPK: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   team?: Maybe<Array<Scalars['Int']> | Scalars['Int']>;
 }>;
 
@@ -6860,7 +6860,7 @@ export type DeleteVisitMutation = (
 
 export type VisitFragment = (
   { __typename?: 'Visit' }
-  & Pick<Visit, 'id' | 'proposalPK' | 'status' | 'questionaryId' | 'visitorId'>
+  & Pick<Visit, 'id' | 'proposalPk' | 'status' | 'questionaryId' | 'visitorId'>
 );
 
 export type GetMyVisitsQueryVariables = Exact<{ [key: string]: never; }>;
@@ -6934,7 +6934,7 @@ export type UpdateVisitMutationVariables = Exact<{
   visitId: Scalars['Int'];
   team?: Maybe<Array<Scalars['Int']> | Scalars['Int']>;
   status?: Maybe<VisitStatus>;
-  proposalPK?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
 }>;
 
 
@@ -7030,7 +7030,7 @@ export const CoreTechnicalReviewFragmentDoc = gql`
   publicComment
   timeAllocation
   status
-  proposalPK
+  proposalPk
   submitted
 }
     `;
@@ -7045,7 +7045,7 @@ export const ProposalStatusFragmentDoc = gql`
     `;
 export const SepMeetingDecisionFragmentDoc = gql`
     fragment sepMeetingDecision on SepMeetingDecision {
-  proposalPK
+  proposalPk
   recommendation
   commentForUser
   commentForManagement
@@ -7270,7 +7270,7 @@ export const SampleFragmentDoc = gql`
   safetyStatus
   safetyComment
   created
-  proposalPK
+  proposalPk
   questionId
 }
     `;
@@ -7278,7 +7278,7 @@ export const ShipmentFragmentDoc = gql`
     fragment shipment on Shipment {
   id
   title
-  proposalPK
+  proposalPk
   status
   externalRef
   questionaryId
@@ -7359,14 +7359,14 @@ export const TemplateStepFragmentDoc = gql`
 export const VisitFragmentDoc = gql`
     fragment visit on Visit {
   id
-  proposalPK
+  proposalPk
   status
   questionaryId
   visitorId
 }
     `;
 export const AssignProposalsToSepDocument = gql`
-    mutation assignProposalsToSep($proposals: [ProposalPKWithCallId!]!, $sepId: Int!) {
+    mutation assignProposalsToSep($proposals: [ProposalPkWithCallId!]!, $sepId: Int!) {
   assignProposalsToSep(proposals: $proposals, sepId: $sepId) {
     rejection {
       ...rejection
@@ -7406,11 +7406,11 @@ export const AssignChairOrSecretaryDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const AssignSepReviewersToProposalDocument = gql`
-    mutation assignSepReviewersToProposal($memberIds: [Int!]!, $sepId: Int!, $proposalPK: Int!) {
+    mutation assignSepReviewersToProposal($memberIds: [Int!]!, $sepId: Int!, $proposalPk: Int!) {
   assignSepReviewersToProposal(
     memberIds: $memberIds
     sepId: $sepId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
   ) {
     rejection {
       ...rejection
@@ -7535,9 +7535,9 @@ export const GetSepMembersDocument = gql`
 }
     `;
 export const GetSepProposalDocument = gql`
-    query getSEPProposal($sepId: Int!, $proposalPK: Int!) {
-  sepProposal(sepId: $sepId, proposalPK: $proposalPK) {
-    proposalPK
+    query getSEPProposal($sepId: Int!, $proposalPk: Int!) {
+  sepProposal(sepId: $sepId, proposalPk: $proposalPk) {
+    proposalPk
     sepId
     sepTimeAllocation
     instrumentSubmitted
@@ -7591,7 +7591,7 @@ ${CoreTechnicalReviewFragmentDoc}`;
 export const GetSepProposalsDocument = gql`
     query getSEPProposals($sepId: Int!, $callId: Int!) {
   sepProposals(sepId: $sepId, callId: $callId) {
-    proposalPK
+    proposalPk
     dateAssigned
     sepId
     sepTimeAllocation
@@ -7706,8 +7706,8 @@ export const GetSePsDocument = gql`
 }
     ${BasicUserDetailsFragmentDoc}`;
 export const RemoveProposalsFromSepDocument = gql`
-    mutation removeProposalsFromSep($proposalPKs: [Int!]!, $sepId: Int!) {
-  removeProposalsFromSep(proposalPKs: $proposalPKs, sepId: $sepId) {
+    mutation removeProposalsFromSep($proposalPks: [Int!]!, $sepId: Int!) {
+  removeProposalsFromSep(proposalPks: $proposalPks, sepId: $sepId) {
     rejection {
       ...rejection
     }
@@ -7730,11 +7730,11 @@ export const RemoveMemberFromSepDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const RemoveMemberFromSepProposalDocument = gql`
-    mutation removeMemberFromSEPProposal($memberId: Int!, $sepId: Int!, $proposalPK: Int!) {
+    mutation removeMemberFromSEPProposal($memberId: Int!, $sepId: Int!, $proposalPk: Int!) {
   removeMemberFromSEPProposal(
     memberId: $memberId
     sepId: $sepId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
   ) {
     rejection {
       ...rejection
@@ -7754,7 +7754,7 @@ export const ReorderSepMeetingDecisionProposalsDocument = gql`
       ...rejection
     }
     sepMeetingDecision {
-      proposalPK
+      proposalPk
     }
   }
 }
@@ -7768,7 +7768,7 @@ export const SaveSepMeetingDecisionDocument = gql`
       ...rejection
     }
     sepMeetingDecision {
-      proposalPK
+      proposalPk
     }
   }
 }
@@ -7792,10 +7792,10 @@ export const UpdateSepDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const UpdateSepTimeAllocationDocument = gql`
-    mutation updateSEPTimeAllocation($sepId: Int!, $proposalPK: Int!, $sepTimeAllocation: Int) {
+    mutation updateSEPTimeAllocation($sepId: Int!, $proposalPk: Int!, $sepTimeAllocation: Int) {
   updateSEPTimeAllocation(
     sepId: $sepId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
     sepTimeAllocation: $sepTimeAllocation
   ) {
     rejection {
@@ -8108,7 +8108,7 @@ export const GetEventLogsDocument = gql`
 }
     `;
 export const AssignProposalsToInstrumentDocument = gql`
-    mutation assignProposalsToInstrument($proposals: [ProposalPKWithCallId!]!, $instrumentId: Int!) {
+    mutation assignProposalsToInstrument($proposals: [ProposalPkWithCallId!]!, $instrumentId: Int!) {
   assignProposalsToInstrument(proposals: $proposals, instrumentId: $instrumentId) {
     rejection {
       ...rejection
@@ -8197,8 +8197,8 @@ export const GetUserInstrumentsDocument = gql`
 }
     ${BasicUserDetailsFragmentDoc}`;
 export const RemoveProposalsFromInstrumentDocument = gql`
-    mutation removeProposalsFromInstrument($proposalPKs: [Int!]!) {
-  removeProposalsFromInstrument(proposalPKs: $proposalPKs) {
+    mutation removeProposalsFromInstrument($proposalPks: [Int!]!) {
+  removeProposalsFromInstrument(proposalPks: $proposalPks) {
     rejection {
       ...rejection
     }
@@ -8290,7 +8290,7 @@ export const AdministrationProposalDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const ChangeProposalsStatusDocument = gql`
-    mutation changeProposalsStatus($proposals: [ProposalPKWithCallId!]!, $statusId: Int!) {
+    mutation changeProposalsStatus($proposals: [ProposalPkWithCallId!]!, $statusId: Int!) {
   changeProposalsStatus(
     changeProposalsStatusInput: {proposals: $proposals, statusId: $statusId}
   ) {
@@ -8726,9 +8726,9 @@ export const GetQuestionaryDocument = gql`
 }
     ${QuestionaryFragmentDoc}`;
 export const AddTechnicalReviewDocument = gql`
-    mutation addTechnicalReview($proposalPK: Int!, $timeAllocation: Int, $comment: String, $publicComment: String, $status: TechnicalReviewStatus, $submitted: Boolean!, $reviewerId: Int!) {
+    mutation addTechnicalReview($proposalPk: Int!, $timeAllocation: Int, $comment: String, $publicComment: String, $status: TechnicalReviewStatus, $submitted: Boolean!, $reviewerId: Int!) {
   addTechnicalReview(
-    addTechnicalReviewInput: {proposalPK: $proposalPK, timeAllocation: $timeAllocation, comment: $comment, publicComment: $publicComment, status: $status, submitted: $submitted, reviewerId: $reviewerId}
+    addTechnicalReviewInput: {proposalPk: $proposalPk, timeAllocation: $timeAllocation, comment: $comment, publicComment: $publicComment, status: $status, submitted: $submitted, reviewerId: $reviewerId}
   ) {
     rejection {
       ...rejection
@@ -8740,8 +8740,8 @@ export const AddTechnicalReviewDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const AddUserForReviewDocument = gql`
-    mutation addUserForReview($userID: Int!, $proposalPK: Int!, $sepID: Int!) {
-  addUserForReview(userID: $userID, proposalPK: $proposalPK, sepID: $sepID) {
+    mutation addUserForReview($userID: Int!, $proposalPk: Int!, $sepID: Int!) {
+  addUserForReview(userID: $userID, proposalPk: $proposalPk, sepID: $sepID) {
     rejection {
       ...rejection
     }
@@ -8752,8 +8752,8 @@ export const AddUserForReviewDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const UpdateTechnicalReviewAssigneeDocument = gql`
-    mutation updateTechnicalReviewAssignee($proposalPKs: [Int!]!, $userId: Int!) {
-  updateTechnicalReviewAssignee(proposalPKs: $proposalPKs, userId: $userId) {
+    mutation updateTechnicalReviewAssignee($proposalPks: [Int!]!, $userId: Int!) {
+  updateTechnicalReviewAssignee(proposalPks: $proposalPks, userId: $userId) {
     proposals {
       ...proposal
     }
@@ -8765,8 +8765,8 @@ export const UpdateTechnicalReviewAssigneeDocument = gql`
     ${ProposalFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const GetProposalReviewsDocument = gql`
-    query getProposalReviews($proposalPK: Int!) {
-  proposalReviews(proposalPK: $proposalPK) {
+    query getProposalReviews($proposalPk: Int!) {
+  proposalReviews(proposalPk: $proposalPk) {
     id
     userID
     comment
@@ -8805,7 +8805,7 @@ export const RemoveUserForReviewDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const SubmitProposalsReviewDocument = gql`
-    mutation submitProposalsReview($proposals: [ProposalPKWithReviewId!]!) {
+    mutation submitProposalsReview($proposals: [ProposalPkWithReviewId!]!) {
   submitProposalsReview(submitProposalsReviewInput: {proposals: $proposals}) {
     rejection {
       ...rejection
@@ -8815,9 +8815,9 @@ export const SubmitProposalsReviewDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const SubmitTechnicalReviewDocument = gql`
-    mutation submitTechnicalReview($proposalPK: Int!, $timeAllocation: Int, $comment: String, $publicComment: String, $status: TechnicalReviewStatus, $submitted: Boolean!, $reviewerId: Int!) {
+    mutation submitTechnicalReview($proposalPk: Int!, $timeAllocation: Int, $comment: String, $publicComment: String, $status: TechnicalReviewStatus, $submitted: Boolean!, $reviewerId: Int!) {
   submitTechnicalReview(
-    submitTechnicalReviewInput: {proposalPK: $proposalPK, timeAllocation: $timeAllocation, comment: $comment, publicComment: $publicComment, status: $status, submitted: $submitted, reviewerId: $reviewerId}
+    submitTechnicalReviewInput: {proposalPk: $proposalPk, timeAllocation: $timeAllocation, comment: $comment, publicComment: $publicComment, status: $status, submitted: $submitted, reviewerId: $reviewerId}
   ) {
     rejection {
       ...rejection
@@ -8908,11 +8908,11 @@ export const CloneSampleDocument = gql`
 ${QuestionaryFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const CreateSampleDocument = gql`
-    mutation createSample($title: String!, $templateId: Int!, $proposalPK: Int!, $questionId: String!) {
+    mutation createSample($title: String!, $templateId: Int!, $proposalPk: Int!, $questionId: String!) {
   createSample(
     title: $title
     templateId: $templateId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
     questionId: $questionId
   ) {
     sample {
@@ -9264,8 +9264,8 @@ export const AddSamplesToShipmentDocument = gql`
 ${ShipmentFragmentDoc}
 ${SampleFragmentDoc}`;
 export const CreateShipmentDocument = gql`
-    mutation createShipment($title: String!, $proposalPK: Int!) {
-  createShipment(title: $title, proposalPK: $proposalPK) {
+    mutation createShipment($title: String!, $proposalPk: Int!) {
+  createShipment(title: $title, proposalPk: $proposalPk) {
     shipment {
       ...shipment
       questionary {
@@ -9349,12 +9349,12 @@ export const SubmitShipmentDocument = gql`
     ${RejectionFragmentDoc}
 ${ShipmentFragmentDoc}`;
 export const UpdateShipmentDocument = gql`
-    mutation updateShipment($shipmentId: Int!, $title: String, $proposalPK: Int, $status: ShipmentStatus) {
+    mutation updateShipment($shipmentId: Int!, $title: String, $proposalPk: Int, $status: ShipmentStatus) {
   updateShipment(
     shipmentId: $shipmentId
     title: $title
     status: $status
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
   ) {
     rejection {
       ...rejection
@@ -10016,8 +10016,8 @@ export const VerifyEmailDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const CreateVisitDocument = gql`
-    mutation createVisit($proposalPK: Int!, $team: [Int!]) {
-  createVisit(proposalPK: $proposalPK, team: $team) {
+    mutation createVisit($proposalPk: Int!, $team: [Int!]) {
+  createVisit(proposalPk: $proposalPk, team: $team) {
     visit {
       ...visit
       questionary {
@@ -10109,10 +10109,10 @@ export const GetVisitsDocument = gql`
     ${VisitFragmentDoc}
 ${ProposalFragmentDoc}`;
 export const UpdateVisitDocument = gql`
-    mutation updateVisit($visitId: Int!, $team: [Int!], $status: VisitStatus, $proposalPK: Int) {
+    mutation updateVisit($visitId: Int!, $team: [Int!], $status: VisitStatus, $proposalPk: Int) {
   updateVisit(
     visitId: $visitId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
     team: $team
     status: $status
   ) {

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -35,7 +35,7 @@ export type AddStatusChangingEventsToConnectionInput = {
 };
 
 export type AddTechnicalReviewInput = {
-  proposalID: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
   timeAllocation?: Maybe<Scalars['Int']>;
@@ -193,7 +193,7 @@ export type CallsFilter = {
 
 export type ChangeProposalsStatusInput = {
   statusId: Scalars['Int'];
-  proposals: Array<ProposalIdWithCallId>;
+  proposals: Array<ProposalPKWithCallId>;
 };
 
 export type CheckExternalTokenWrap = {
@@ -802,13 +802,13 @@ export type MutationChangeProposalsStatusArgs = {
 
 
 export type MutationAssignProposalsToInstrumentArgs = {
-  proposals: Array<ProposalIdWithCallId>;
+  proposals: Array<ProposalPKWithCallId>;
   instrumentId: Scalars['Int'];
 };
 
 
 export type MutationRemoveProposalsFromInstrumentArgs = {
-  proposalIds: Array<Scalars['Int']>;
+  proposalPKs: Array<Scalars['Int']>;
 };
 
 
@@ -950,7 +950,7 @@ export type MutationAddReviewArgs = {
 
 export type MutationAddUserForReviewArgs = {
   userID: Scalars['Int'];
-  proposalID: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   sepID: Scalars['Int'];
 };
 
@@ -962,14 +962,14 @@ export type MutationSubmitProposalsReviewArgs = {
 
 export type MutationUpdateTechnicalReviewAssigneeArgs = {
   userId: Scalars['Int'];
-  proposalIds: Array<Scalars['Int']>;
+  proposalPKs: Array<Scalars['Int']>;
 };
 
 
 export type MutationCreateSampleArgs = {
   title: Scalars['String'];
   templateId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   questionId: Scalars['String'];
 };
 
@@ -1003,25 +1003,25 @@ export type MutationRemoveMemberFromSepArgs = {
 export type MutationAssignSepReviewersToProposalArgs = {
   memberIds: Array<Scalars['Int']>;
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 };
 
 
 export type MutationRemoveMemberFromSepProposalArgs = {
   memberId: Scalars['Int'];
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 };
 
 
 export type MutationAssignProposalsToSepArgs = {
-  proposals: Array<ProposalIdWithCallId>;
+  proposals: Array<ProposalPKWithCallId>;
   sepId: Scalars['Int'];
 };
 
 
 export type MutationRemoveProposalsFromSepArgs = {
-  proposalIds: Array<Scalars['Int']>;
+  proposalPKs: Array<Scalars['Int']>;
   sepId: Scalars['Int'];
 };
 
@@ -1055,20 +1055,20 @@ export type MutationUpdateSepArgs = {
 
 export type MutationUpdateSepTimeAllocationArgs = {
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   sepTimeAllocation?: Maybe<Scalars['Int']>;
 };
 
 
 export type MutationCreateShipmentArgs = {
   title: Scalars['String'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 };
 
 
 export type MutationUpdateShipmentArgs = {
   shipmentId: Scalars['Int'];
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPK?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   status?: Maybe<ShipmentStatus>;
   externalRef?: Maybe<Scalars['String']>;
@@ -1272,7 +1272,7 @@ export type MutationCreateProposalArgs = {
 
 
 export type MutationCreateVisitArgs = {
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   team?: Maybe<Array<Scalars['Int']>>;
 };
 
@@ -1436,7 +1436,7 @@ export type MutationUpdatePasswordArgs = {
 export type MutationUpdateVisitArgs = {
   visitId: Scalars['Int'];
   status?: Maybe<VisitStatus>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPK?: Maybe<Scalars['Int']>;
   team?: Maybe<Array<Scalars['Int']>>;
 };
 
@@ -1684,18 +1684,18 @@ export type ProposalEvent = {
   description: Maybe<Scalars['String']>;
 };
 
-export type ProposalIdWithCallId = {
+export type ProposalPKWithCallId = {
   id: Scalars['Int'];
   callId: Scalars['Int'];
 };
 
-export type ProposalIdWithRankOrder = {
-  proposalId: Scalars['Int'];
+export type ProposalPKWithRankOrder = {
+  proposalPK: Scalars['Int'];
   rankOrder: Scalars['Int'];
 };
 
-export type ProposalIdWithReviewId = {
-  proposalId: Scalars['Int'];
+export type ProposalPKWithReviewId = {
+  proposalPK: Scalars['Int'];
   reviewId: Scalars['Int'];
 };
 
@@ -2056,7 +2056,7 @@ export type QueryInstrumentScientistHasInstrumentArgs = {
 
 
 export type QueryInstrumentScientistHasAccessArgs = {
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   instrumentId: Scalars['Int'];
 };
 
@@ -2072,7 +2072,7 @@ export type QueryProposalArgs = {
 
 
 export type QueryUserHasAccessToProposalArgs = {
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 };
 
 
@@ -2108,7 +2108,7 @@ export type QueryReviewArgs = {
 
 
 export type QueryProposalReviewsArgs = {
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 };
 
 
@@ -2149,7 +2149,7 @@ export type QuerySepProposalsArgs = {
 
 
 export type QuerySepProposalArgs = {
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   sepId: Scalars['Int'];
 };
 
@@ -2354,7 +2354,7 @@ export type RemoveAssignedInstrumentFromCallInput = {
 };
 
 export type ReorderSepMeetingDecisionProposalsInput = {
-  proposals: Array<ProposalIdWithRankOrder>;
+  proposals: Array<ProposalPKWithRankOrder>;
 };
 
 export type Review = {
@@ -2432,7 +2432,7 @@ export type Sep = {
 
 export type SepAssignment = {
   __typename?: 'SEPAssignment';
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   sepMemberUserId: Maybe<Scalars['Int']>;
   sepId: Scalars['Int'];
   dateAssigned: Scalars['DateTime'];
@@ -2447,7 +2447,7 @@ export type SepAssignment = {
 
 export type SepProposal = {
   __typename?: 'SEPProposal';
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   sepId: Scalars['Int'];
   dateAssigned: Scalars['DateTime'];
   sepTimeAllocation: Maybe<Scalars['Int']>;
@@ -2488,7 +2488,7 @@ export type Sample = {
   title: Scalars['String'];
   creatorId: Scalars['Int'];
   questionaryId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   questionId: Scalars['String'];
   safetyStatus: SampleStatus;
   safetyComment: Scalars['String'];
@@ -2522,11 +2522,11 @@ export type SamplesFilter = {
   sampleIds?: Maybe<Array<Scalars['Int']>>;
   status?: Maybe<SampleStatus>;
   questionId?: Maybe<Scalars['String']>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPK?: Maybe<Scalars['Int']>;
 };
 
 export type SaveSepMeetingDecisionInput = {
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   commentForUser?: Maybe<Scalars['String']>;
   commentForManagement?: Maybe<Scalars['String']>;
   recommendation?: Maybe<ProposalEndStatus>;
@@ -2595,7 +2595,7 @@ export type SelectionFromOptionsConfig = {
 
 export type SepMeetingDecision = {
   __typename?: 'SepMeetingDecision';
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   recommendation: Maybe<ProposalEndStatus>;
   commentForManagement: Maybe<Scalars['String']>;
   commentForUser: Maybe<Scalars['String']>;
@@ -2625,7 +2625,7 @@ export type Shipment = {
   __typename?: 'Shipment';
   id: Scalars['Int'];
   title: Scalars['String'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   status: ShipmentStatus;
   externalRef: Maybe<Scalars['String']>;
   questionaryId: Scalars['Int'];
@@ -2657,7 +2657,7 @@ export enum ShipmentStatus {
 export type ShipmentsFilter = {
   title?: Maybe<Scalars['String']>;
   creatorId?: Maybe<Scalars['Int']>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPK?: Maybe<Scalars['Int']>;
   questionaryIds?: Maybe<Array<Scalars['Int']>>;
   status?: Maybe<ShipmentStatus>;
   externalRef?: Maybe<Scalars['String']>;
@@ -2686,11 +2686,11 @@ export type StatusChangingEvent = {
 };
 
 export type SubmitProposalsReviewInput = {
-  proposals: Array<ProposalIdWithReviewId>;
+  proposals: Array<ProposalPKWithReviewId>;
 };
 
 export type SubmitTechnicalReviewInput = {
-  proposalID: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
   timeAllocation?: Maybe<Scalars['Int']>;
@@ -2719,7 +2719,7 @@ export type SuccessResponseWrap = {
 export type TechnicalReview = {
   __typename?: 'TechnicalReview';
   id: Scalars['Int'];
-  proposalID: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   comment: Maybe<Scalars['String']>;
   publicComment: Maybe<Scalars['String']>;
   timeAllocation: Maybe<Scalars['Int']>;
@@ -2961,7 +2961,7 @@ export enum UserRole {
 export type Visit = {
   __typename?: 'Visit';
   id: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   status: VisitStatus;
   questionaryId: Scalars['Int'];
   visitorId: Scalars['Int'];
@@ -2992,11 +2992,11 @@ export enum VisitStatus {
 export type VisitsFilter = {
   visitorId?: Maybe<Scalars['Int']>;
   questionaryId?: Maybe<Scalars['Int']>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPK?: Maybe<Scalars['Int']>;
 };
 
 export type AssignProposalsToSepMutationVariables = Exact<{
-  proposals: Array<ProposalIdWithCallId> | ProposalIdWithCallId;
+  proposals: Array<ProposalPKWithCallId> | ProposalPKWithCallId;
   sepId: Scalars['Int'];
 }>;
 
@@ -3057,7 +3057,7 @@ export type AssignChairOrSecretaryMutation = (
 export type AssignSepReviewersToProposalMutationVariables = Exact<{
   memberIds: Array<Scalars['Int']> | Scalars['Int'];
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 }>;
 
 
@@ -3125,7 +3125,7 @@ export type DeleteSepMutation = (
 
 export type SepMeetingDecisionFragment = (
   { __typename?: 'SepMeetingDecision' }
-  & Pick<SepMeetingDecision, 'proposalId' | 'recommendation' | 'commentForUser' | 'commentForManagement' | 'rankOrder' | 'submitted' | 'submittedBy'>
+  & Pick<SepMeetingDecision, 'proposalPK' | 'recommendation' | 'commentForUser' | 'commentForManagement' | 'rankOrder' | 'submitted' | 'submittedBy'>
 );
 
 export type GetInstrumentsBySepQueryVariables = Exact<{
@@ -3209,7 +3209,7 @@ export type GetSepMembersQuery = (
 
 export type GetSepProposalQueryVariables = Exact<{
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 }>;
 
 
@@ -3217,7 +3217,7 @@ export type GetSepProposalQuery = (
   { __typename?: 'Query' }
   & { sepProposal: Maybe<(
     { __typename?: 'SEPProposal' }
-    & Pick<SepProposal, 'proposalId' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'>
+    & Pick<SepProposal, 'proposalPK' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'>
     & { proposal: (
       { __typename?: 'Proposal' }
       & { proposer: Maybe<(
@@ -3265,7 +3265,7 @@ export type GetSepProposalsQuery = (
   { __typename?: 'Query' }
   & { sepProposals: Maybe<Array<(
     { __typename?: 'SEPProposal' }
-    & Pick<SepProposal, 'proposalId' | 'dateAssigned' | 'sepId' | 'sepTimeAllocation'>
+    & Pick<SepProposal, 'proposalPK' | 'dateAssigned' | 'sepId' | 'sepTimeAllocation'>
     & { proposal: (
       { __typename?: 'Proposal' }
       & Pick<Proposal, 'title' | 'id' | 'shortCode'>
@@ -3371,7 +3371,7 @@ export type GetSePsQuery = (
 );
 
 export type RemoveProposalsFromSepMutationVariables = Exact<{
-  proposalIds: Array<Scalars['Int']> | Scalars['Int'];
+  proposalPKs: Array<Scalars['Int']> | Scalars['Int'];
   sepId: Scalars['Int'];
 }>;
 
@@ -3414,7 +3414,7 @@ export type RemoveMemberFromSepMutation = (
 export type RemoveMemberFromSepProposalMutationVariables = Exact<{
   memberId: Scalars['Int'];
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 }>;
 
 
@@ -3446,7 +3446,7 @@ export type ReorderSepMeetingDecisionProposalsMutation = (
       & RejectionFragment
     )>, sepMeetingDecision: Maybe<(
       { __typename?: 'SepMeetingDecision' }
-      & Pick<SepMeetingDecision, 'proposalId'>
+      & Pick<SepMeetingDecision, 'proposalPK'>
     )> }
   ) }
 );
@@ -3465,7 +3465,7 @@ export type SaveSepMeetingDecisionMutation = (
       & RejectionFragment
     )>, sepMeetingDecision: Maybe<(
       { __typename?: 'SepMeetingDecision' }
-      & Pick<SepMeetingDecision, 'proposalId'>
+      & Pick<SepMeetingDecision, 'proposalPK'>
     )> }
   ) }
 );
@@ -3495,7 +3495,7 @@ export type UpdateSepMutation = (
 
 export type UpdateSepTimeAllocationMutationVariables = Exact<{
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   sepTimeAllocation?: Maybe<Scalars['Int']>;
 }>;
 
@@ -3992,7 +3992,7 @@ export type GetEventLogsQuery = (
 );
 
 export type AssignProposalsToInstrumentMutationVariables = Exact<{
-  proposals: Array<ProposalIdWithCallId> | ProposalIdWithCallId;
+  proposals: Array<ProposalPKWithCallId> | ProposalPKWithCallId;
   instrumentId: Scalars['Int'];
 }>;
 
@@ -4109,7 +4109,7 @@ export type GetUserInstrumentsQuery = (
 );
 
 export type RemoveProposalsFromInstrumentMutationVariables = Exact<{
-  proposalIds: Array<Scalars['Int']> | Scalars['Int'];
+  proposalPKs: Array<Scalars['Int']> | Scalars['Int'];
 }>;
 
 
@@ -4234,7 +4234,7 @@ export type AdministrationProposalMutation = (
 );
 
 export type ChangeProposalsStatusMutationVariables = Exact<{
-  proposals: Array<ProposalIdWithCallId> | ProposalIdWithCallId;
+  proposals: Array<ProposalPKWithCallId> | ProposalPKWithCallId;
   statusId: Scalars['Int'];
 }>;
 
@@ -4358,7 +4358,7 @@ export type DeleteProposalMutation = (
 
 export type CoreTechnicalReviewFragment = (
   { __typename?: 'TechnicalReview' }
-  & Pick<TechnicalReview, 'id' | 'comment' | 'publicComment' | 'timeAllocation' | 'status' | 'proposalID' | 'submitted'>
+  & Pick<TechnicalReview, 'id' | 'comment' | 'publicComment' | 'timeAllocation' | 'status' | 'proposalPK' | 'submitted'>
 );
 
 export type ProposalFragment = (
@@ -4802,7 +4802,7 @@ export type GetQuestionaryQuery = (
 );
 
 export type AddTechnicalReviewMutationVariables = Exact<{
-  proposalID: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   timeAllocation?: Maybe<Scalars['Int']>;
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
@@ -4828,7 +4828,7 @@ export type AddTechnicalReviewMutation = (
 
 export type AddUserForReviewMutationVariables = Exact<{
   userID: Scalars['Int'];
-  proposalID: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   sepID: Scalars['Int'];
 }>;
 
@@ -4848,7 +4848,7 @@ export type AddUserForReviewMutation = (
 );
 
 export type UpdateTechnicalReviewAssigneeMutationVariables = Exact<{
-  proposalIds: Array<Scalars['Int']> | Scalars['Int'];
+  proposalPKs: Array<Scalars['Int']> | Scalars['Int'];
   userId: Scalars['Int'];
 }>;
 
@@ -4873,7 +4873,7 @@ export type CoreReviewFragment = (
 );
 
 export type GetProposalReviewsQueryVariables = Exact<{
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 }>;
 
 
@@ -4928,7 +4928,7 @@ export type RemoveUserForReviewMutation = (
 );
 
 export type SubmitProposalsReviewMutationVariables = Exact<{
-  proposals: Array<ProposalIdWithReviewId> | ProposalIdWithReviewId;
+  proposals: Array<ProposalPKWithReviewId> | ProposalPKWithReviewId;
 }>;
 
 
@@ -4945,7 +4945,7 @@ export type SubmitProposalsReviewMutation = (
 );
 
 export type SubmitTechnicalReviewMutationVariables = Exact<{
-  proposalID: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   timeAllocation?: Maybe<Scalars['Int']>;
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
@@ -5054,7 +5054,7 @@ export type CloneSampleMutation = (
 export type CreateSampleMutationVariables = Exact<{
   title: Scalars['String'];
   templateId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   questionId: Scalars['String'];
 }>;
 
@@ -5099,7 +5099,7 @@ export type DeleteSampleMutation = (
 
 export type SampleFragment = (
   { __typename?: 'Sample' }
-  & Pick<Sample, 'id' | 'title' | 'creatorId' | 'questionaryId' | 'safetyStatus' | 'safetyComment' | 'created' | 'proposalId' | 'questionId'>
+  & Pick<Sample, 'id' | 'title' | 'creatorId' | 'questionaryId' | 'safetyStatus' | 'safetyComment' | 'created' | 'proposalPK' | 'questionId'>
 );
 
 export type GetSampleQueryVariables = Exact<{
@@ -5519,7 +5519,7 @@ export type AddSamplesToShipmentMutation = (
 
 export type CreateShipmentMutationVariables = Exact<{
   title: Scalars['String'];
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
 }>;
 
 
@@ -5562,7 +5562,7 @@ export type DeleteShipmentMutation = (
 
 export type ShipmentFragment = (
   { __typename?: 'Shipment' }
-  & Pick<Shipment, 'id' | 'title' | 'proposalId' | 'status' | 'externalRef' | 'questionaryId' | 'creatorId' | 'created'>
+  & Pick<Shipment, 'id' | 'title' | 'proposalPK' | 'status' | 'externalRef' | 'questionaryId' | 'creatorId' | 'created'>
   & { proposal: (
     { __typename?: 'Proposal' }
     & Pick<Proposal, 'shortCode'>
@@ -5653,7 +5653,7 @@ export type SubmitShipmentMutation = (
 export type UpdateShipmentMutationVariables = Exact<{
   shipmentId: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPK?: Maybe<Scalars['Int']>;
   status?: Maybe<ShipmentStatus>;
 }>;
 
@@ -6806,7 +6806,7 @@ export type VerifyEmailMutation = (
 );
 
 export type CreateVisitMutationVariables = Exact<{
-  proposalId: Scalars['Int'];
+  proposalPK: Scalars['Int'];
   team?: Maybe<Array<Scalars['Int']> | Scalars['Int']>;
 }>;
 
@@ -6860,7 +6860,7 @@ export type DeleteVisitMutation = (
 
 export type VisitFragment = (
   { __typename?: 'Visit' }
-  & Pick<Visit, 'id' | 'proposalId' | 'status' | 'questionaryId' | 'visitorId'>
+  & Pick<Visit, 'id' | 'proposalPK' | 'status' | 'questionaryId' | 'visitorId'>
 );
 
 export type GetMyVisitsQueryVariables = Exact<{ [key: string]: never; }>;
@@ -6934,7 +6934,7 @@ export type UpdateVisitMutationVariables = Exact<{
   visitId: Scalars['Int'];
   team?: Maybe<Array<Scalars['Int']> | Scalars['Int']>;
   status?: Maybe<VisitStatus>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPK?: Maybe<Scalars['Int']>;
 }>;
 
 
@@ -7030,7 +7030,7 @@ export const CoreTechnicalReviewFragmentDoc = gql`
   publicComment
   timeAllocation
   status
-  proposalID
+  proposalPK
   submitted
 }
     `;
@@ -7045,7 +7045,7 @@ export const ProposalStatusFragmentDoc = gql`
     `;
 export const SepMeetingDecisionFragmentDoc = gql`
     fragment sepMeetingDecision on SepMeetingDecision {
-  proposalId
+  proposalPK
   recommendation
   commentForUser
   commentForManagement
@@ -7270,7 +7270,7 @@ export const SampleFragmentDoc = gql`
   safetyStatus
   safetyComment
   created
-  proposalId
+  proposalPK
   questionId
 }
     `;
@@ -7278,7 +7278,7 @@ export const ShipmentFragmentDoc = gql`
     fragment shipment on Shipment {
   id
   title
-  proposalId
+  proposalPK
   status
   externalRef
   questionaryId
@@ -7359,14 +7359,14 @@ export const TemplateStepFragmentDoc = gql`
 export const VisitFragmentDoc = gql`
     fragment visit on Visit {
   id
-  proposalId
+  proposalPK
   status
   questionaryId
   visitorId
 }
     `;
 export const AssignProposalsToSepDocument = gql`
-    mutation assignProposalsToSep($proposals: [ProposalIdWithCallId!]!, $sepId: Int!) {
+    mutation assignProposalsToSep($proposals: [ProposalPKWithCallId!]!, $sepId: Int!) {
   assignProposalsToSep(proposals: $proposals, sepId: $sepId) {
     rejection {
       ...rejection
@@ -7406,11 +7406,11 @@ export const AssignChairOrSecretaryDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const AssignSepReviewersToProposalDocument = gql`
-    mutation assignSepReviewersToProposal($memberIds: [Int!]!, $sepId: Int!, $proposalId: Int!) {
+    mutation assignSepReviewersToProposal($memberIds: [Int!]!, $sepId: Int!, $proposalPK: Int!) {
   assignSepReviewersToProposal(
     memberIds: $memberIds
     sepId: $sepId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
   ) {
     rejection {
       ...rejection
@@ -7535,9 +7535,9 @@ export const GetSepMembersDocument = gql`
 }
     `;
 export const GetSepProposalDocument = gql`
-    query getSEPProposal($sepId: Int!, $proposalId: Int!) {
-  sepProposal(sepId: $sepId, proposalId: $proposalId) {
-    proposalId
+    query getSEPProposal($sepId: Int!, $proposalPK: Int!) {
+  sepProposal(sepId: $sepId, proposalPK: $proposalPK) {
+    proposalPK
     sepId
     sepTimeAllocation
     instrumentSubmitted
@@ -7591,7 +7591,7 @@ ${CoreTechnicalReviewFragmentDoc}`;
 export const GetSepProposalsDocument = gql`
     query getSEPProposals($sepId: Int!, $callId: Int!) {
   sepProposals(sepId: $sepId, callId: $callId) {
-    proposalId
+    proposalPK
     dateAssigned
     sepId
     sepTimeAllocation
@@ -7706,8 +7706,8 @@ export const GetSePsDocument = gql`
 }
     ${BasicUserDetailsFragmentDoc}`;
 export const RemoveProposalsFromSepDocument = gql`
-    mutation removeProposalsFromSep($proposalIds: [Int!]!, $sepId: Int!) {
-  removeProposalsFromSep(proposalIds: $proposalIds, sepId: $sepId) {
+    mutation removeProposalsFromSep($proposalPKs: [Int!]!, $sepId: Int!) {
+  removeProposalsFromSep(proposalPKs: $proposalPKs, sepId: $sepId) {
     rejection {
       ...rejection
     }
@@ -7730,11 +7730,11 @@ export const RemoveMemberFromSepDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const RemoveMemberFromSepProposalDocument = gql`
-    mutation removeMemberFromSEPProposal($memberId: Int!, $sepId: Int!, $proposalId: Int!) {
+    mutation removeMemberFromSEPProposal($memberId: Int!, $sepId: Int!, $proposalPK: Int!) {
   removeMemberFromSEPProposal(
     memberId: $memberId
     sepId: $sepId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
   ) {
     rejection {
       ...rejection
@@ -7754,7 +7754,7 @@ export const ReorderSepMeetingDecisionProposalsDocument = gql`
       ...rejection
     }
     sepMeetingDecision {
-      proposalId
+      proposalPK
     }
   }
 }
@@ -7768,7 +7768,7 @@ export const SaveSepMeetingDecisionDocument = gql`
       ...rejection
     }
     sepMeetingDecision {
-      proposalId
+      proposalPK
     }
   }
 }
@@ -7792,10 +7792,10 @@ export const UpdateSepDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const UpdateSepTimeAllocationDocument = gql`
-    mutation updateSEPTimeAllocation($sepId: Int!, $proposalId: Int!, $sepTimeAllocation: Int) {
+    mutation updateSEPTimeAllocation($sepId: Int!, $proposalPK: Int!, $sepTimeAllocation: Int) {
   updateSEPTimeAllocation(
     sepId: $sepId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
     sepTimeAllocation: $sepTimeAllocation
   ) {
     rejection {
@@ -8108,7 +8108,7 @@ export const GetEventLogsDocument = gql`
 }
     `;
 export const AssignProposalsToInstrumentDocument = gql`
-    mutation assignProposalsToInstrument($proposals: [ProposalIdWithCallId!]!, $instrumentId: Int!) {
+    mutation assignProposalsToInstrument($proposals: [ProposalPKWithCallId!]!, $instrumentId: Int!) {
   assignProposalsToInstrument(proposals: $proposals, instrumentId: $instrumentId) {
     rejection {
       ...rejection
@@ -8197,8 +8197,8 @@ export const GetUserInstrumentsDocument = gql`
 }
     ${BasicUserDetailsFragmentDoc}`;
 export const RemoveProposalsFromInstrumentDocument = gql`
-    mutation removeProposalsFromInstrument($proposalIds: [Int!]!) {
-  removeProposalsFromInstrument(proposalIds: $proposalIds) {
+    mutation removeProposalsFromInstrument($proposalPKs: [Int!]!) {
+  removeProposalsFromInstrument(proposalPKs: $proposalPKs) {
     rejection {
       ...rejection
     }
@@ -8290,7 +8290,7 @@ export const AdministrationProposalDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const ChangeProposalsStatusDocument = gql`
-    mutation changeProposalsStatus($proposals: [ProposalIdWithCallId!]!, $statusId: Int!) {
+    mutation changeProposalsStatus($proposals: [ProposalPKWithCallId!]!, $statusId: Int!) {
   changeProposalsStatus(
     changeProposalsStatusInput: {proposals: $proposals, statusId: $statusId}
   ) {
@@ -8726,9 +8726,9 @@ export const GetQuestionaryDocument = gql`
 }
     ${QuestionaryFragmentDoc}`;
 export const AddTechnicalReviewDocument = gql`
-    mutation addTechnicalReview($proposalID: Int!, $timeAllocation: Int, $comment: String, $publicComment: String, $status: TechnicalReviewStatus, $submitted: Boolean!, $reviewerId: Int!) {
+    mutation addTechnicalReview($proposalPK: Int!, $timeAllocation: Int, $comment: String, $publicComment: String, $status: TechnicalReviewStatus, $submitted: Boolean!, $reviewerId: Int!) {
   addTechnicalReview(
-    addTechnicalReviewInput: {proposalID: $proposalID, timeAllocation: $timeAllocation, comment: $comment, publicComment: $publicComment, status: $status, submitted: $submitted, reviewerId: $reviewerId}
+    addTechnicalReviewInput: {proposalPK: $proposalPK, timeAllocation: $timeAllocation, comment: $comment, publicComment: $publicComment, status: $status, submitted: $submitted, reviewerId: $reviewerId}
   ) {
     rejection {
       ...rejection
@@ -8740,8 +8740,8 @@ export const AddTechnicalReviewDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const AddUserForReviewDocument = gql`
-    mutation addUserForReview($userID: Int!, $proposalID: Int!, $sepID: Int!) {
-  addUserForReview(userID: $userID, proposalID: $proposalID, sepID: $sepID) {
+    mutation addUserForReview($userID: Int!, $proposalPK: Int!, $sepID: Int!) {
+  addUserForReview(userID: $userID, proposalPK: $proposalPK, sepID: $sepID) {
     rejection {
       ...rejection
     }
@@ -8752,8 +8752,8 @@ export const AddUserForReviewDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const UpdateTechnicalReviewAssigneeDocument = gql`
-    mutation updateTechnicalReviewAssignee($proposalIds: [Int!]!, $userId: Int!) {
-  updateTechnicalReviewAssignee(proposalIds: $proposalIds, userId: $userId) {
+    mutation updateTechnicalReviewAssignee($proposalPKs: [Int!]!, $userId: Int!) {
+  updateTechnicalReviewAssignee(proposalPKs: $proposalPKs, userId: $userId) {
     proposals {
       ...proposal
     }
@@ -8765,8 +8765,8 @@ export const UpdateTechnicalReviewAssigneeDocument = gql`
     ${ProposalFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const GetProposalReviewsDocument = gql`
-    query getProposalReviews($proposalId: Int!) {
-  proposalReviews(proposalId: $proposalId) {
+    query getProposalReviews($proposalPK: Int!) {
+  proposalReviews(proposalPK: $proposalPK) {
     id
     userID
     comment
@@ -8805,7 +8805,7 @@ export const RemoveUserForReviewDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const SubmitProposalsReviewDocument = gql`
-    mutation submitProposalsReview($proposals: [ProposalIdWithReviewId!]!) {
+    mutation submitProposalsReview($proposals: [ProposalPKWithReviewId!]!) {
   submitProposalsReview(submitProposalsReviewInput: {proposals: $proposals}) {
     rejection {
       ...rejection
@@ -8815,9 +8815,9 @@ export const SubmitProposalsReviewDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const SubmitTechnicalReviewDocument = gql`
-    mutation submitTechnicalReview($proposalID: Int!, $timeAllocation: Int, $comment: String, $publicComment: String, $status: TechnicalReviewStatus, $submitted: Boolean!, $reviewerId: Int!) {
+    mutation submitTechnicalReview($proposalPK: Int!, $timeAllocation: Int, $comment: String, $publicComment: String, $status: TechnicalReviewStatus, $submitted: Boolean!, $reviewerId: Int!) {
   submitTechnicalReview(
-    submitTechnicalReviewInput: {proposalID: $proposalID, timeAllocation: $timeAllocation, comment: $comment, publicComment: $publicComment, status: $status, submitted: $submitted, reviewerId: $reviewerId}
+    submitTechnicalReviewInput: {proposalPK: $proposalPK, timeAllocation: $timeAllocation, comment: $comment, publicComment: $publicComment, status: $status, submitted: $submitted, reviewerId: $reviewerId}
   ) {
     rejection {
       ...rejection
@@ -8908,11 +8908,11 @@ export const CloneSampleDocument = gql`
 ${QuestionaryFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const CreateSampleDocument = gql`
-    mutation createSample($title: String!, $templateId: Int!, $proposalId: Int!, $questionId: String!) {
+    mutation createSample($title: String!, $templateId: Int!, $proposalPK: Int!, $questionId: String!) {
   createSample(
     title: $title
     templateId: $templateId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
     questionId: $questionId
   ) {
     sample {
@@ -9264,8 +9264,8 @@ export const AddSamplesToShipmentDocument = gql`
 ${ShipmentFragmentDoc}
 ${SampleFragmentDoc}`;
 export const CreateShipmentDocument = gql`
-    mutation createShipment($title: String!, $proposalId: Int!) {
-  createShipment(title: $title, proposalId: $proposalId) {
+    mutation createShipment($title: String!, $proposalPK: Int!) {
+  createShipment(title: $title, proposalPK: $proposalPK) {
     shipment {
       ...shipment
       questionary {
@@ -9349,12 +9349,12 @@ export const SubmitShipmentDocument = gql`
     ${RejectionFragmentDoc}
 ${ShipmentFragmentDoc}`;
 export const UpdateShipmentDocument = gql`
-    mutation updateShipment($shipmentId: Int!, $title: String, $proposalId: Int, $status: ShipmentStatus) {
+    mutation updateShipment($shipmentId: Int!, $title: String, $proposalPK: Int, $status: ShipmentStatus) {
   updateShipment(
     shipmentId: $shipmentId
     title: $title
     status: $status
-    proposalId: $proposalId
+    proposalPK: $proposalPK
   ) {
     rejection {
       ...rejection
@@ -10016,8 +10016,8 @@ export const VerifyEmailDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const CreateVisitDocument = gql`
-    mutation createVisit($proposalId: Int!, $team: [Int!]) {
-  createVisit(proposalId: $proposalId, team: $team) {
+    mutation createVisit($proposalPK: Int!, $team: [Int!]) {
+  createVisit(proposalPK: $proposalPK, team: $team) {
     visit {
       ...visit
       questionary {
@@ -10109,10 +10109,10 @@ export const GetVisitsDocument = gql`
     ${VisitFragmentDoc}
 ${ProposalFragmentDoc}`;
 export const UpdateVisitDocument = gql`
-    mutation updateVisit($visitId: Int!, $team: [Int!], $status: VisitStatus, $proposalId: Int) {
+    mutation updateVisit($visitId: Int!, $team: [Int!], $status: VisitStatus, $proposalPK: Int) {
   updateVisit(
     visitId: $visitId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
     team: $team
     status: $status
   ) {

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -1593,7 +1593,7 @@ export type Proposal = {
   statusId: Scalars['Int'];
   created: Scalars['DateTime'];
   updated: Scalars['DateTime'];
-  shortCode: Scalars['String'];
+  proposalId: Scalars['String'];
   finalStatus: Maybe<ProposalEndStatus>;
   callId: Scalars['Int'];
   questionaryId: Scalars['Int'];
@@ -1763,7 +1763,7 @@ export type ProposalView = {
   statusId: Scalars['Int'];
   statusName: Scalars['String'];
   statusDescription: Scalars['String'];
-  shortCode: Scalars['String'];
+  proposalId: Scalars['String'];
   rankOrder: Maybe<Scalars['Int']>;
   finalStatus: Maybe<ProposalEndStatus>;
   notified: Scalars['Boolean'];
@@ -3268,7 +3268,7 @@ export type GetSepProposalsQuery = (
     & Pick<SepProposal, 'proposalPk' | 'dateAssigned' | 'sepId' | 'sepTimeAllocation'>
     & { proposal: (
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'title' | 'primaryKey' | 'shortCode'>
+      & Pick<Proposal, 'title' | 'primaryKey' | 'proposalId'>
       & { status: Maybe<(
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
@@ -3304,7 +3304,7 @@ export type SepProposalsByInstrumentQuery = (
     & Pick<SepProposal, 'sepTimeAllocation'>
     & { proposal: (
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
       & { status: Maybe<(
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
@@ -4308,7 +4308,7 @@ export type CreateProposalMutation = (
     { __typename?: 'ProposalResponseWrap' }
     & { proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'shortCode' | 'questionaryId'>
+      & Pick<Proposal, 'primaryKey' | 'proposalId' | 'questionaryId'>
       & { status: Maybe<(
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
@@ -4363,7 +4363,7 @@ export type CoreTechnicalReviewFragment = (
 
 export type ProposalFragment = (
   { __typename?: 'Proposal' }
-  & Pick<Proposal, 'primaryKey' | 'title' | 'abstract' | 'statusId' | 'publicStatus' | 'shortCode' | 'finalStatus' | 'commentForUser' | 'commentForManagement' | 'created' | 'updated' | 'callId' | 'questionaryId' | 'notified' | 'submitted' | 'managementTimeAllocation' | 'managementDecisionSubmitted' | 'technicalReviewAssignee'>
+  & Pick<Proposal, 'primaryKey' | 'title' | 'abstract' | 'statusId' | 'publicStatus' | 'proposalId' | 'finalStatus' | 'commentForUser' | 'commentForManagement' | 'created' | 'updated' | 'callId' | 'questionaryId' | 'notified' | 'submitted' | 'managementTimeAllocation' | 'managementDecisionSubmitted' | 'technicalReviewAssignee'>
   & { status: Maybe<(
     { __typename?: 'ProposalStatus' }
     & ProposalStatusFragment
@@ -4542,7 +4542,7 @@ export type GetProposalsCoreQuery = (
   { __typename?: 'Query' }
   & { proposalsView: Maybe<Array<(
     { __typename?: 'ProposalView' }
-    & Pick<ProposalView, 'primaryKey' | 'title' | 'statusId' | 'statusName' | 'statusDescription' | 'shortCode' | 'rankOrder' | 'finalStatus' | 'notified' | 'timeAllocation' | 'technicalStatus' | 'instrumentName' | 'callShortCode' | 'sepCode' | 'sepId' | 'reviewAverage' | 'reviewDeviation' | 'instrumentId' | 'callId' | 'submitted' | 'allocationTimeUnit'>
+    & Pick<ProposalView, 'primaryKey' | 'title' | 'statusId' | 'statusName' | 'statusDescription' | 'proposalId' | 'rankOrder' | 'finalStatus' | 'notified' | 'timeAllocation' | 'technicalStatus' | 'instrumentName' | 'callShortCode' | 'sepCode' | 'sepId' | 'reviewAverage' | 'reviewDeviation' | 'instrumentId' | 'callId' | 'submitted' | 'allocationTimeUnit'>
   )>> }
 );
 
@@ -4627,7 +4627,7 @@ export type GetUserProposalBookingsWithEventsQuery = (
     { __typename?: 'User' }
     & { proposals: Array<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
       & { proposalBooking: Maybe<(
         { __typename?: 'ProposalBooking' }
         & { scheduledEvents: Array<(
@@ -5014,7 +5014,7 @@ export type UserWithReviewsQuery = (
       & Pick<Review, 'id' | 'grade' | 'comment' | 'status' | 'sepID'>
       & { proposal: Maybe<(
         { __typename?: 'Proposal' }
-        & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
+        & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
         & { call: Maybe<(
           { __typename?: 'Call' }
           & Pick<Call, 'shortCode'>
@@ -5131,7 +5131,7 @@ export type GetSamplesByCallIdQuery = (
     { __typename?: 'Sample' }
     & { proposal: (
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'proposalId'>
     ) }
     & SampleFragment
   )>> }
@@ -5148,7 +5148,7 @@ export type GetSamplesWithProposalDataQuery = (
     { __typename?: 'Sample' }
     & { proposal: (
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'proposalId'>
     ) }
     & SampleFragment
   )>> }
@@ -5565,7 +5565,7 @@ export type ShipmentFragment = (
   & Pick<Shipment, 'id' | 'title' | 'proposalPk' | 'status' | 'externalRef' | 'questionaryId' | 'creatorId' | 'created'>
   & { proposal: (
     { __typename?: 'Proposal' }
-    & Pick<Proposal, 'shortCode'>
+    & Pick<Proposal, 'proposalId'>
   ) }
 );
 
@@ -6563,7 +6563,7 @@ export type GetUserProposalsQuery = (
     { __typename?: 'User' }
     & { proposals: Array<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'shortCode' | 'title' | 'publicStatus' | 'statusId' | 'created' | 'finalStatus' | 'notified' | 'submitted'>
+      & Pick<Proposal, 'primaryKey' | 'proposalId' | 'title' | 'publicStatus' | 'statusId' | 'created' | 'finalStatus' | 'notified' | 'submitted'>
       & { status: Maybe<(
         { __typename?: 'ProposalStatus' }
         & ProposalStatusFragment
@@ -7064,7 +7064,7 @@ export const ProposalFragmentDoc = gql`
     ...proposalStatus
   }
   publicStatus
-  shortCode
+  proposalId
   finalStatus
   commentForUser
   commentForManagement
@@ -7285,7 +7285,7 @@ export const ShipmentFragmentDoc = gql`
   creatorId
   created
   proposal {
-    shortCode
+    proposalId
   }
 }
     `;
@@ -7598,7 +7598,7 @@ export const GetSepProposalsDocument = gql`
     proposal {
       title
       primaryKey
-      shortCode
+      proposalId
       status {
         ...proposalStatus
       }
@@ -7637,7 +7637,7 @@ export const SepProposalsByInstrumentDocument = gql`
     proposal {
       primaryKey
       title
-      shortCode
+      proposalId
       status {
         ...proposalStatus
       }
@@ -8362,7 +8362,7 @@ export const CreateProposalDocument = gql`
       status {
         ...proposalStatus
       }
-      shortCode
+      proposalId
       questionaryId
       questionary {
         ...questionary
@@ -8577,7 +8577,7 @@ export const GetProposalsCoreDocument = gql`
     statusId
     statusName
     statusDescription
-    shortCode
+    proposalId
     rankOrder
     finalStatus
     notified
@@ -8654,7 +8654,7 @@ export const GetUserProposalBookingsWithEventsDocument = gql`
     proposals(filter: {instrumentId: $instrumentId}) {
       primaryKey
       title
-      shortCode
+      proposalId
       proposalBooking(filter: {status: $status}) {
         scheduledEvents(filter: {endsAfter: $endsAfter}) {
           startsAt
@@ -8877,7 +8877,7 @@ export const UserWithReviewsDocument = gql`
       proposal {
         primaryKey
         title
-        shortCode
+        proposalId
         call {
           shortCode
         }
@@ -8961,7 +8961,7 @@ export const GetSamplesByCallIdDocument = gql`
     ...sample
     proposal {
       primaryKey
-      shortCode
+      proposalId
     }
   }
 }
@@ -8972,7 +8972,7 @@ export const GetSamplesWithProposalDataDocument = gql`
     ...sample
     proposal {
       primaryKey
-      shortCode
+      proposalId
     }
   }
 }
@@ -9847,7 +9847,7 @@ export const GetUserProposalsDocument = gql`
   me {
     proposals {
       primaryKey
-      shortCode
+      proposalId
       title
       status {
         ...proposalStatus

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -204,7 +204,7 @@ export type CheckExternalTokenWrap = {
 
 export type CloneProposalInput = {
   callId: Scalars['Int'];
-  proposalToCloneId: Scalars['Int'];
+  proposalToClonePk: Scalars['Int'];
 };
 
 export type ConfirmEquipmentAssignmentInput = {
@@ -856,7 +856,7 @@ export type MutationSubmitInstrumentArgs = {
 
 
 export type MutationAdministrationProposalArgs = {
-  primaryKey: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   commentForUser?: Maybe<Scalars['String']>;
   commentForManagement?: Maybe<Scalars['String']>;
   finalStatus?: Maybe<ProposalEndStatus>;
@@ -872,7 +872,7 @@ export type MutationCloneProposalArgs = {
 
 
 export type MutationUpdateProposalArgs = {
-  primaryKey: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
   abstract?: Maybe<Scalars['String']>;
   users?: Maybe<Array<Scalars['Int']>>;
@@ -1293,7 +1293,7 @@ export type MutationDeleteInstrumentArgs = {
 
 
 export type MutationDeleteProposalArgs = {
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
@@ -1359,7 +1359,7 @@ export type MutationLoginArgs = {
 
 
 export type MutationNotifyProposalArgs = {
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
@@ -1402,7 +1402,7 @@ export type MutationDeleteProposalWorkflowArgs = {
 
 
 export type MutationSubmitProposalArgs = {
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
@@ -4209,7 +4209,7 @@ export type UpdateInstrumentMutation = (
 );
 
 export type AdministrationProposalMutationVariables = Exact<{
-  primaryKey: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   finalStatus?: Maybe<ProposalEndStatus>;
   statusId?: Maybe<Scalars['Int']>;
   commentForUser?: Maybe<Scalars['String']>;
@@ -4252,7 +4252,7 @@ export type ChangeProposalsStatusMutation = (
 );
 
 export type CloneProposalMutationVariables = Exact<{
-  proposalToCloneId: Scalars['Int'];
+  proposalToClonePk: Scalars['Int'];
   callId: Scalars['Int'];
 }>;
 
@@ -4338,7 +4338,7 @@ export type CreateProposalMutation = (
 );
 
 export type DeleteProposalMutationVariables = Exact<{
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 }>;
 
 
@@ -4547,7 +4547,7 @@ export type GetProposalsCoreQuery = (
 );
 
 export type NotifyProposalMutationVariables = Exact<{
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 }>;
 
 
@@ -4566,7 +4566,7 @@ export type NotifyProposalMutation = (
 );
 
 export type SubmitProposalMutationVariables = Exact<{
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 }>;
 
 
@@ -4585,7 +4585,7 @@ export type SubmitProposalMutation = (
 );
 
 export type UpdateProposalMutationVariables = Exact<{
-  primaryKey: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
   abstract?: Maybe<Scalars['String']>;
   users?: Maybe<Array<Scalars['Int']> | Scalars['Int']>;
@@ -8270,9 +8270,9 @@ export const UpdateInstrumentDocument = gql`
     ${BasicUserDetailsFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const AdministrationProposalDocument = gql`
-    mutation administrationProposal($primaryKey: Int!, $finalStatus: ProposalEndStatus, $statusId: Int, $commentForUser: String, $commentForManagement: String, $managementTimeAllocation: Int, $managementDecisionSubmitted: Boolean) {
+    mutation administrationProposal($proposalPk: Int!, $finalStatus: ProposalEndStatus, $statusId: Int, $commentForUser: String, $commentForManagement: String, $managementTimeAllocation: Int, $managementDecisionSubmitted: Boolean) {
   administrationProposal(
-    primaryKey: $primaryKey
+    proposalPk: $proposalPk
     finalStatus: $finalStatus
     statusId: $statusId
     commentForUser: $commentForUser
@@ -8302,9 +8302,9 @@ export const ChangeProposalsStatusDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const CloneProposalDocument = gql`
-    mutation cloneProposal($proposalToCloneId: Int!, $callId: Int!) {
+    mutation cloneProposal($proposalToClonePk: Int!, $callId: Int!) {
   cloneProposal(
-    cloneProposalInput: {proposalToCloneId: $proposalToCloneId, callId: $callId}
+    cloneProposalInput: {proposalToClonePk: $proposalToClonePk, callId: $callId}
   ) {
     proposal {
       ...proposal
@@ -8392,8 +8392,8 @@ ${BasicUserDetailsFragmentDoc}
 ${SampleFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const DeleteProposalDocument = gql`
-    mutation deleteProposal($id: Int!) {
-  deleteProposal(id: $id) {
+    mutation deleteProposal($proposalPk: Int!) {
+  deleteProposal(proposalPk: $proposalPk) {
     rejection {
       ...rejection
     }
@@ -8597,8 +8597,8 @@ export const GetProposalsCoreDocument = gql`
 }
     `;
 export const NotifyProposalDocument = gql`
-    mutation notifyProposal($id: Int!) {
-  notifyProposal(id: $id) {
+    mutation notifyProposal($proposalPk: Int!) {
+  notifyProposal(proposalPk: $proposalPk) {
     proposal {
       primaryKey
     }
@@ -8609,8 +8609,8 @@ export const NotifyProposalDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const SubmitProposalDocument = gql`
-    mutation submitProposal($id: Int!) {
-  submitProposal(id: $id) {
+    mutation submitProposal($proposalPk: Int!) {
+  submitProposal(proposalPk: $proposalPk) {
     proposal {
       ...proposal
     }
@@ -8622,9 +8622,9 @@ export const SubmitProposalDocument = gql`
     ${ProposalFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const UpdateProposalDocument = gql`
-    mutation updateProposal($primaryKey: Int!, $title: String, $abstract: String, $users: [Int!], $proposerId: Int) {
+    mutation updateProposal($proposalPk: Int!, $title: String, $abstract: String, $users: [Int!], $proposerId: Int) {
   updateProposal(
-    primaryKey: $primaryKey
+    proposalPk: $proposalPk
     title: $title
     abstract: $abstract
     users: $users

--- a/src/graphql/SEP/assignProposalsToSep.graphql
+++ b/src/graphql/SEP/assignProposalsToSep.graphql
@@ -1,5 +1,5 @@
 mutation assignProposalsToSep(
-  $proposals: [ProposalPKWithCallId!]!
+  $proposals: [ProposalPkWithCallId!]!
   $sepId: Int!
 ) {
   assignProposalsToSep(proposals: $proposals, sepId: $sepId) {

--- a/src/graphql/SEP/assignProposalsToSep.graphql
+++ b/src/graphql/SEP/assignProposalsToSep.graphql
@@ -1,5 +1,5 @@
 mutation assignProposalsToSep(
-  $proposals: [ProposalIdWithCallId!]!
+  $proposals: [ProposalPKWithCallId!]!
   $sepId: Int!
 ) {
   assignProposalsToSep(proposals: $proposals, sepId: $sepId) {

--- a/src/graphql/SEP/assignSepReviewersToProposal.graphql
+++ b/src/graphql/SEP/assignSepReviewersToProposal.graphql
@@ -1,12 +1,12 @@
 mutation assignSepReviewersToProposal(
   $memberIds: [Int!]!
   $sepId: Int!
-  $proposalPK: Int!
+  $proposalPk: Int!
 ) {
   assignSepReviewersToProposal(
     memberIds: $memberIds
     sepId: $sepId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
   ) {
     rejection {
       ...rejection

--- a/src/graphql/SEP/assignSepReviewersToProposal.graphql
+++ b/src/graphql/SEP/assignSepReviewersToProposal.graphql
@@ -1,12 +1,12 @@
 mutation assignSepReviewersToProposal(
   $memberIds: [Int!]!
   $sepId: Int!
-  $proposalId: Int!
+  $proposalPK: Int!
 ) {
   assignSepReviewersToProposal(
     memberIds: $memberIds
     sepId: $sepId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
   ) {
     rejection {
       ...rejection

--- a/src/graphql/SEP/fragment.sepMeetingDecision.graphql
+++ b/src/graphql/SEP/fragment.sepMeetingDecision.graphql
@@ -1,5 +1,5 @@
 fragment sepMeetingDecision on SepMeetingDecision {
-  proposalId
+  proposalPK
   recommendation
   commentForUser
   commentForManagement

--- a/src/graphql/SEP/fragment.sepMeetingDecision.graphql
+++ b/src/graphql/SEP/fragment.sepMeetingDecision.graphql
@@ -1,5 +1,5 @@
 fragment sepMeetingDecision on SepMeetingDecision {
-  proposalPK
+  proposalPk
   recommendation
   commentForUser
   commentForManagement

--- a/src/graphql/SEP/getSEPProposal.graphql
+++ b/src/graphql/SEP/getSEPProposal.graphql
@@ -1,6 +1,6 @@
-query getSEPProposal($sepId: Int!, $proposalPK: Int!) {
-  sepProposal(sepId: $sepId, proposalPK: $proposalPK) {
-    proposalPK
+query getSEPProposal($sepId: Int!, $proposalPk: Int!) {
+  sepProposal(sepId: $sepId, proposalPk: $proposalPk) {
+    proposalPk
     sepId
     sepTimeAllocation
 

--- a/src/graphql/SEP/getSEPProposal.graphql
+++ b/src/graphql/SEP/getSEPProposal.graphql
@@ -1,6 +1,6 @@
-query getSEPProposal($sepId: Int!, $proposalId: Int!) {
-  sepProposal(sepId: $sepId, proposalId: $proposalId) {
-    proposalId
+query getSEPProposal($sepId: Int!, $proposalPK: Int!) {
+  sepProposal(sepId: $sepId, proposalPK: $proposalPK) {
+    proposalPK
     sepId
     sepTimeAllocation
 

--- a/src/graphql/SEP/getSEPProposals.graphql
+++ b/src/graphql/SEP/getSEPProposals.graphql
@@ -7,7 +7,7 @@ query getSEPProposals($sepId: Int!, $callId: Int!) {
     proposal {
       title
       primaryKey
-      shortCode
+      proposalId
       status {
         ...proposalStatus
       }

--- a/src/graphql/SEP/getSEPProposals.graphql
+++ b/src/graphql/SEP/getSEPProposals.graphql
@@ -1,6 +1,6 @@
 query getSEPProposals($sepId: Int!, $callId: Int!) {
   sepProposals(sepId: $sepId, callId: $callId) {
-    proposalPK
+    proposalPk
     dateAssigned
     sepId
     sepTimeAllocation

--- a/src/graphql/SEP/getSEPProposals.graphql
+++ b/src/graphql/SEP/getSEPProposals.graphql
@@ -1,6 +1,6 @@
 query getSEPProposals($sepId: Int!, $callId: Int!) {
   sepProposals(sepId: $sepId, callId: $callId) {
-    proposalId
+    proposalPK
     dateAssigned
     sepId
     sepTimeAllocation

--- a/src/graphql/SEP/getSEPProposals.graphql
+++ b/src/graphql/SEP/getSEPProposals.graphql
@@ -6,7 +6,7 @@ query getSEPProposals($sepId: Int!, $callId: Int!) {
     sepTimeAllocation
     proposal {
       title
-      id
+      primaryKey
       shortCode
       status {
         ...proposalStatus

--- a/src/graphql/SEP/getSEPProposalsByInstrument.graphql
+++ b/src/graphql/SEP/getSEPProposalsByInstrument.graphql
@@ -12,7 +12,7 @@ query sepProposalsByInstrument(
     proposal {
       primaryKey
       title
-      shortCode
+      proposalId
       status {
         ...proposalStatus
       }

--- a/src/graphql/SEP/getSEPProposalsByInstrument.graphql
+++ b/src/graphql/SEP/getSEPProposalsByInstrument.graphql
@@ -10,7 +10,7 @@ query sepProposalsByInstrument(
   ) {
     sepTimeAllocation
     proposal {
-      id
+      primaryKey
       title
       shortCode
       status {

--- a/src/graphql/SEP/removeProposalsFromSep.graphql
+++ b/src/graphql/SEP/removeProposalsFromSep.graphql
@@ -1,5 +1,5 @@
-mutation removeProposalsFromSep($proposalIds: [Int!]!, $sepId: Int!) {
-  removeProposalsFromSep(proposalIds: $proposalIds, sepId: $sepId) {
+mutation removeProposalsFromSep($proposalPKs: [Int!]!, $sepId: Int!) {
+  removeProposalsFromSep(proposalPKs: $proposalPKs, sepId: $sepId) {
     rejection {
       ...rejection
     }

--- a/src/graphql/SEP/removeProposalsFromSep.graphql
+++ b/src/graphql/SEP/removeProposalsFromSep.graphql
@@ -1,5 +1,5 @@
-mutation removeProposalsFromSep($proposalPKs: [Int!]!, $sepId: Int!) {
-  removeProposalsFromSep(proposalPKs: $proposalPKs, sepId: $sepId) {
+mutation removeProposalsFromSep($proposalPks: [Int!]!, $sepId: Int!) {
+  removeProposalsFromSep(proposalPks: $proposalPks, sepId: $sepId) {
     rejection {
       ...rejection
     }

--- a/src/graphql/SEP/removeSEPMemberFromProposal.graphql
+++ b/src/graphql/SEP/removeSEPMemberFromProposal.graphql
@@ -1,12 +1,12 @@
 mutation removeMemberFromSEPProposal(
   $memberId: Int!
   $sepId: Int!
-  $proposalPK: Int!
+  $proposalPk: Int!
 ) {
   removeMemberFromSEPProposal(
     memberId: $memberId
     sepId: $sepId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
   ) {
     rejection {
       ...rejection

--- a/src/graphql/SEP/removeSEPMemberFromProposal.graphql
+++ b/src/graphql/SEP/removeSEPMemberFromProposal.graphql
@@ -1,12 +1,12 @@
 mutation removeMemberFromSEPProposal(
   $memberId: Int!
   $sepId: Int!
-  $proposalId: Int!
+  $proposalPK: Int!
 ) {
   removeMemberFromSEPProposal(
     memberId: $memberId
     sepId: $sepId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
   ) {
     rejection {
       ...rejection

--- a/src/graphql/SEP/reorderSepMeetingDecisionProposals.graphql
+++ b/src/graphql/SEP/reorderSepMeetingDecisionProposals.graphql
@@ -8,7 +8,7 @@ mutation reorderSepMeetingDecisionProposals(
       ...rejection
     }
     sepMeetingDecision {
-      proposalPK
+      proposalPk
     }
   }
 }

--- a/src/graphql/SEP/reorderSepMeetingDecisionProposals.graphql
+++ b/src/graphql/SEP/reorderSepMeetingDecisionProposals.graphql
@@ -8,7 +8,7 @@ mutation reorderSepMeetingDecisionProposals(
       ...rejection
     }
     sepMeetingDecision {
-      proposalId
+      proposalPK
     }
   }
 }

--- a/src/graphql/SEP/saveSepMeetingDecision.graphql
+++ b/src/graphql/SEP/saveSepMeetingDecision.graphql
@@ -8,7 +8,7 @@ mutation saveSepMeetingDecision(
       ...rejection
     }
     sepMeetingDecision {
-      proposalId
+      proposalPK
     }
   }
 }

--- a/src/graphql/SEP/saveSepMeetingDecision.graphql
+++ b/src/graphql/SEP/saveSepMeetingDecision.graphql
@@ -8,7 +8,7 @@ mutation saveSepMeetingDecision(
       ...rejection
     }
     sepMeetingDecision {
-      proposalPK
+      proposalPk
     }
   }
 }

--- a/src/graphql/SEP/updateSEPTimeAllocation.graphql
+++ b/src/graphql/SEP/updateSEPTimeAllocation.graphql
@@ -1,11 +1,11 @@
 mutation updateSEPTimeAllocation(
   $sepId: Int!
-  $proposalPK: Int!
+  $proposalPk: Int!
   $sepTimeAllocation: Int
 ) {
   updateSEPTimeAllocation(
     sepId: $sepId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
     sepTimeAllocation: $sepTimeAllocation
   ) {
     rejection {

--- a/src/graphql/SEP/updateSEPTimeAllocation.graphql
+++ b/src/graphql/SEP/updateSEPTimeAllocation.graphql
@@ -1,11 +1,11 @@
 mutation updateSEPTimeAllocation(
   $sepId: Int!
-  $proposalId: Int!
+  $proposalPK: Int!
   $sepTimeAllocation: Int
 ) {
   updateSEPTimeAllocation(
     sepId: $sepId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
     sepTimeAllocation: $sepTimeAllocation
   ) {
     rejection {

--- a/src/graphql/instrument/assignProposalsToInstrument.graphql
+++ b/src/graphql/instrument/assignProposalsToInstrument.graphql
@@ -1,5 +1,5 @@
 mutation assignProposalsToInstrument(
-  $proposals: [ProposalIdWithCallId!]!
+  $proposals: [ProposalPKWithCallId!]!
   $instrumentId: Int!
 ) {
   assignProposalsToInstrument(

--- a/src/graphql/instrument/assignProposalsToInstrument.graphql
+++ b/src/graphql/instrument/assignProposalsToInstrument.graphql
@@ -1,5 +1,5 @@
 mutation assignProposalsToInstrument(
-  $proposals: [ProposalPKWithCallId!]!
+  $proposals: [ProposalPkWithCallId!]!
   $instrumentId: Int!
 ) {
   assignProposalsToInstrument(

--- a/src/graphql/instrument/removeProposalFromInstrument.graphql
+++ b/src/graphql/instrument/removeProposalFromInstrument.graphql
@@ -1,5 +1,5 @@
-mutation removeProposalsFromInstrument($proposalPKs: [Int!]!) {
-  removeProposalsFromInstrument(proposalPKs: $proposalPKs) {
+mutation removeProposalsFromInstrument($proposalPks: [Int!]!) {
+  removeProposalsFromInstrument(proposalPks: $proposalPks) {
     rejection {
       ...rejection
     }

--- a/src/graphql/instrument/removeProposalFromInstrument.graphql
+++ b/src/graphql/instrument/removeProposalFromInstrument.graphql
@@ -1,5 +1,5 @@
-mutation removeProposalsFromInstrument($proposalIds: [Int!]!) {
-  removeProposalsFromInstrument(proposalIds: $proposalIds) {
+mutation removeProposalsFromInstrument($proposalPKs: [Int!]!) {
+  removeProposalsFromInstrument(proposalPKs: $proposalPKs) {
     rejection {
       ...rejection
     }

--- a/src/graphql/proposal/administrationProposal.graphql
+++ b/src/graphql/proposal/administrationProposal.graphql
@@ -1,5 +1,5 @@
 mutation administrationProposal(
-  $primaryKey: Int!
+  $proposalPk: Int!
   $finalStatus: ProposalEndStatus
   $statusId: Int
   $commentForUser: String
@@ -8,7 +8,7 @@ mutation administrationProposal(
   $managementDecisionSubmitted: Boolean
 ) {
   administrationProposal(
-    primaryKey: $primaryKey
+    proposalPk: $proposalPk
     finalStatus: $finalStatus
     statusId: $statusId
     commentForUser: $commentForUser

--- a/src/graphql/proposal/administrationProposal.graphql
+++ b/src/graphql/proposal/administrationProposal.graphql
@@ -1,5 +1,5 @@
 mutation administrationProposal(
-  $id: Int!
+  $primaryKey: Int!
   $finalStatus: ProposalEndStatus
   $statusId: Int
   $commentForUser: String
@@ -8,7 +8,7 @@ mutation administrationProposal(
   $managementDecisionSubmitted: Boolean
 ) {
   administrationProposal(
-    id: $id
+    primaryKey: $primaryKey
     finalStatus: $finalStatus
     statusId: $statusId
     commentForUser: $commentForUser
@@ -17,7 +17,7 @@ mutation administrationProposal(
     managementDecisionSubmitted: $managementDecisionSubmitted
   ) {
     proposal {
-      id
+      primaryKey
     }
     rejection {
       ...rejection

--- a/src/graphql/proposal/changeProposalsStatus.graphql
+++ b/src/graphql/proposal/changeProposalsStatus.graphql
@@ -1,5 +1,5 @@
 mutation changeProposalsStatus(
-  $proposals: [ProposalIdWithCallId!]!
+  $proposals: [ProposalPKWithCallId!]!
   $statusId: Int!
 ) {
   changeProposalsStatus(

--- a/src/graphql/proposal/changeProposalsStatus.graphql
+++ b/src/graphql/proposal/changeProposalsStatus.graphql
@@ -1,5 +1,5 @@
 mutation changeProposalsStatus(
-  $proposals: [ProposalPKWithCallId!]!
+  $proposals: [ProposalPkWithCallId!]!
   $statusId: Int!
 ) {
   changeProposalsStatus(

--- a/src/graphql/proposal/cloneProposal.graphql
+++ b/src/graphql/proposal/cloneProposal.graphql
@@ -1,7 +1,7 @@
-mutation cloneProposal($proposalToCloneId: Int!, $callId: Int!) {
+mutation cloneProposal($proposalToClonePk: Int!, $callId: Int!) {
   cloneProposal(
     cloneProposalInput: {
-      proposalToCloneId: $proposalToCloneId
+      proposalToClonePk: $proposalToClonePk
       callId: $callId
     }
   ) {

--- a/src/graphql/proposal/createProposal.graphql
+++ b/src/graphql/proposal/createProposal.graphql
@@ -5,7 +5,7 @@ mutation createProposal($callId: Int!) {
       status {
         ...proposalStatus
       }
-      shortCode
+      proposalId
       questionaryId
       questionary {
         ...questionary

--- a/src/graphql/proposal/createProposal.graphql
+++ b/src/graphql/proposal/createProposal.graphql
@@ -1,7 +1,7 @@
 mutation createProposal($callId: Int!) {
   createProposal(callId: $callId) {
     proposal {
-      id
+      primaryKey
       status {
         ...proposalStatus
       }

--- a/src/graphql/proposal/deleteProposal.graphql
+++ b/src/graphql/proposal/deleteProposal.graphql
@@ -4,7 +4,7 @@ mutation deleteProposal($id: Int!) {
       ...rejection
     }
     proposal {
-      id
+      primaryKey
     }
   }
 }

--- a/src/graphql/proposal/deleteProposal.graphql
+++ b/src/graphql/proposal/deleteProposal.graphql
@@ -1,5 +1,5 @@
-mutation deleteProposal($id: Int!) {
-  deleteProposal(id: $id) {
+mutation deleteProposal($proposalPk: Int!) {
+  deleteProposal(proposalPk: $proposalPk) {
     rejection {
       ...rejection
     }

--- a/src/graphql/proposal/fragment.coreTechnicalReview.graphql
+++ b/src/graphql/proposal/fragment.coreTechnicalReview.graphql
@@ -4,6 +4,6 @@ fragment coreTechnicalReview on TechnicalReview {
   publicComment
   timeAllocation
   status
-  proposalPK
+  proposalPk
   submitted
 }

--- a/src/graphql/proposal/fragment.coreTechnicalReview.graphql
+++ b/src/graphql/proposal/fragment.coreTechnicalReview.graphql
@@ -4,6 +4,6 @@ fragment coreTechnicalReview on TechnicalReview {
   publicComment
   timeAllocation
   status
-  proposalID
+  proposalPK
   submitted
 }

--- a/src/graphql/proposal/fragment.proposal.graphql
+++ b/src/graphql/proposal/fragment.proposal.graphql
@@ -1,5 +1,5 @@
 fragment proposal on Proposal {
-  id
+  primaryKey
   title
   abstract
   statusId

--- a/src/graphql/proposal/fragment.proposal.graphql
+++ b/src/graphql/proposal/fragment.proposal.graphql
@@ -7,7 +7,7 @@ fragment proposal on Proposal {
     ...proposalStatus
   }
   publicStatus
-  shortCode
+  proposalId
   finalStatus
   commentForUser
   commentForManagement

--- a/src/graphql/proposal/getProposal.graphql
+++ b/src/graphql/proposal/getProposal.graphql
@@ -1,5 +1,5 @@
-query getProposal($id: Int!) {
-  proposal(id: $id) {
+query getProposal($primaryKey: Int!) {
+  proposal(primaryKey: $primaryKey) {
     ...proposal
     proposer {
       ...basicUserDetails

--- a/src/graphql/proposal/getProposalsCore.graphql
+++ b/src/graphql/proposal/getProposalsCore.graphql
@@ -1,6 +1,6 @@
 query getProposalsCore($filter: ProposalsFilter) {
   proposalsView(filter: $filter) {
-    id
+    primaryKey
     title
     statusId
     statusName

--- a/src/graphql/proposal/getProposalsCore.graphql
+++ b/src/graphql/proposal/getProposalsCore.graphql
@@ -5,7 +5,7 @@ query getProposalsCore($filter: ProposalsFilter) {
     statusId
     statusName
     statusDescription
-    shortCode
+    proposalId
     rankOrder
     finalStatus
     notified

--- a/src/graphql/proposal/notifyProposal.graphql
+++ b/src/graphql/proposal/notifyProposal.graphql
@@ -1,5 +1,5 @@
-mutation notifyProposal($id: Int!) {
-  notifyProposal(id: $id) {
+mutation notifyProposal($proposalPk: Int!) {
+  notifyProposal(proposalPk: $proposalPk) {
     proposal {
       primaryKey
     }

--- a/src/graphql/proposal/notifyProposal.graphql
+++ b/src/graphql/proposal/notifyProposal.graphql
@@ -1,7 +1,7 @@
 mutation notifyProposal($id: Int!) {
   notifyProposal(id: $id) {
     proposal {
-      id
+      primaryKey
     }
     rejection {
       ...rejection

--- a/src/graphql/proposal/submitProposal.graphql
+++ b/src/graphql/proposal/submitProposal.graphql
@@ -1,5 +1,5 @@
-mutation submitProposal($id: Int!) {
-  submitProposal(id: $id) {
+mutation submitProposal($proposalPk: Int!) {
+  submitProposal(proposalPk: $proposalPk) {
     proposal {
       ...proposal
     }

--- a/src/graphql/proposal/updateProposal.graphql
+++ b/src/graphql/proposal/updateProposal.graphql
@@ -1,12 +1,12 @@
 mutation updateProposal(
-  $primaryKey: Int!
+  $proposalPk: Int!
   $title: String
   $abstract: String
   $users: [Int!]
   $proposerId: Int
 ) {
   updateProposal(
-    primaryKey: $primaryKey
+    proposalPk: $proposalPk
     title: $title
     abstract: $abstract
     users: $users

--- a/src/graphql/proposal/updateProposal.graphql
+++ b/src/graphql/proposal/updateProposal.graphql
@@ -13,7 +13,7 @@ mutation updateProposal(
     proposerId: $proposerId
   ) {
     proposal {
-      id
+      primaryKey
       title
       abstract
       proposer {

--- a/src/graphql/proposal/updateProposal.graphql
+++ b/src/graphql/proposal/updateProposal.graphql
@@ -1,12 +1,12 @@
 mutation updateProposal(
-  $id: Int!
+  $primaryKey: Int!
   $title: String
   $abstract: String
   $users: [Int!]
   $proposerId: Int
 ) {
   updateProposal(
-    id: $id
+    primaryKey: $primaryKey
     title: $title
     abstract: $abstract
     users: $users

--- a/src/graphql/proposalBooking/getUserProposalBookingsWithEvents.graphql
+++ b/src/graphql/proposalBooking/getUserProposalBookingsWithEvents.graphql
@@ -7,7 +7,7 @@ query getUserProposalBookingsWithEvents(
     proposals(filter: { instrumentId: $instrumentId }) {
       primaryKey
       title
-      shortCode
+      proposalId
       proposalBooking(filter: { status: $status }) {
         scheduledEvents(filter: { endsAfter: $endsAfter }) {
           startsAt

--- a/src/graphql/proposalBooking/getUserProposalBookingsWithEvents.graphql
+++ b/src/graphql/proposalBooking/getUserProposalBookingsWithEvents.graphql
@@ -5,7 +5,7 @@ query getUserProposalBookingsWithEvents(
 ) {
   me {
     proposals(filter: { instrumentId: $instrumentId }) {
-      id
+      primaryKey
       title
       shortCode
       proposalBooking(filter: { status: $status }) {

--- a/src/graphql/review/addTechnicalReview.graphql
+++ b/src/graphql/review/addTechnicalReview.graphql
@@ -1,5 +1,5 @@
 mutation addTechnicalReview(
-  $proposalID: Int!
+  $proposalPK: Int!
   $timeAllocation: Int
   $comment: String
   $publicComment: String
@@ -9,7 +9,7 @@ mutation addTechnicalReview(
 ) {
   addTechnicalReview(
     addTechnicalReviewInput: {
-      proposalID: $proposalID
+      proposalPK: $proposalPK
       timeAllocation: $timeAllocation
       comment: $comment
       publicComment: $publicComment

--- a/src/graphql/review/addTechnicalReview.graphql
+++ b/src/graphql/review/addTechnicalReview.graphql
@@ -1,5 +1,5 @@
 mutation addTechnicalReview(
-  $proposalPK: Int!
+  $proposalPk: Int!
   $timeAllocation: Int
   $comment: String
   $publicComment: String
@@ -9,7 +9,7 @@ mutation addTechnicalReview(
 ) {
   addTechnicalReview(
     addTechnicalReviewInput: {
-      proposalPK: $proposalPK
+      proposalPk: $proposalPk
       timeAllocation: $timeAllocation
       comment: $comment
       publicComment: $publicComment

--- a/src/graphql/review/addUserForReview.graphql
+++ b/src/graphql/review/addUserForReview.graphql
@@ -1,5 +1,5 @@
-mutation addUserForReview($userID: Int!, $proposalID: Int!, $sepID: Int!) {
-  addUserForReview(userID: $userID, proposalID: $proposalID, sepID: $sepID) {
+mutation addUserForReview($userID: Int!, $proposalPK: Int!, $sepID: Int!) {
+  addUserForReview(userID: $userID, proposalPK: $proposalPK, sepID: $sepID) {
     rejection {
       ...rejection
     }

--- a/src/graphql/review/addUserForReview.graphql
+++ b/src/graphql/review/addUserForReview.graphql
@@ -1,5 +1,5 @@
-mutation addUserForReview($userID: Int!, $proposalPK: Int!, $sepID: Int!) {
-  addUserForReview(userID: $userID, proposalPK: $proposalPK, sepID: $sepID) {
+mutation addUserForReview($userID: Int!, $proposalPk: Int!, $sepID: Int!) {
+  addUserForReview(userID: $userID, proposalPk: $proposalPk, sepID: $sepID) {
     rejection {
       ...rejection
     }

--- a/src/graphql/review/assignTechnicalReviewToUser.graphql
+++ b/src/graphql/review/assignTechnicalReviewToUser.graphql
@@ -1,5 +1,5 @@
-mutation updateTechnicalReviewAssignee($proposalIds: [Int!]!, $userId: Int!) {
-  updateTechnicalReviewAssignee(proposalIds: $proposalIds, userId: $userId) {
+mutation updateTechnicalReviewAssignee($proposalPKs: [Int!]!, $userId: Int!) {
+  updateTechnicalReviewAssignee(proposalPKs: $proposalPKs, userId: $userId) {
     proposals {
       ...proposal
     }

--- a/src/graphql/review/assignTechnicalReviewToUser.graphql
+++ b/src/graphql/review/assignTechnicalReviewToUser.graphql
@@ -1,5 +1,5 @@
-mutation updateTechnicalReviewAssignee($proposalPKs: [Int!]!, $userId: Int!) {
-  updateTechnicalReviewAssignee(proposalPKs: $proposalPKs, userId: $userId) {
+mutation updateTechnicalReviewAssignee($proposalPks: [Int!]!, $userId: Int!) {
+  updateTechnicalReviewAssignee(proposalPks: $proposalPks, userId: $userId) {
     proposals {
       ...proposal
     }

--- a/src/graphql/review/getProposalReviews.graphql
+++ b/src/graphql/review/getProposalReviews.graphql
@@ -1,5 +1,5 @@
-query getProposalReviews($proposalId: Int!) {
-  proposalReviews(proposalId: $proposalId) {
+query getProposalReviews($proposalPK: Int!) {
+  proposalReviews(proposalPK: $proposalPK) {
     id
     userID
     comment

--- a/src/graphql/review/getProposalReviews.graphql
+++ b/src/graphql/review/getProposalReviews.graphql
@@ -1,5 +1,5 @@
-query getProposalReviews($proposalPK: Int!) {
-  proposalReviews(proposalPK: $proposalPK) {
+query getProposalReviews($proposalPk: Int!) {
+  proposalReviews(proposalPk: $proposalPk) {
     id
     userID
     comment

--- a/src/graphql/review/getReview.graphql
+++ b/src/graphql/review/getReview.graphql
@@ -2,7 +2,7 @@ query getReview($reviewId: Int!, $sepId: Int) {
   review(reviewId: $reviewId, sepId: $sepId) {
     ...coreReview
     proposal {
-      id
+      primaryKey
       title
       abstract
       proposer {

--- a/src/graphql/review/submitProposalsReview.graphql
+++ b/src/graphql/review/submitProposalsReview.graphql
@@ -1,4 +1,4 @@
-mutation submitProposalsReview($proposals: [ProposalIdWithReviewId!]!) {
+mutation submitProposalsReview($proposals: [ProposalPKWithReviewId!]!) {
   submitProposalsReview(submitProposalsReviewInput: { proposals: $proposals }) {
     rejection {
       ...rejection

--- a/src/graphql/review/submitProposalsReview.graphql
+++ b/src/graphql/review/submitProposalsReview.graphql
@@ -1,4 +1,4 @@
-mutation submitProposalsReview($proposals: [ProposalPKWithReviewId!]!) {
+mutation submitProposalsReview($proposals: [ProposalPkWithReviewId!]!) {
   submitProposalsReview(submitProposalsReviewInput: { proposals: $proposals }) {
     rejection {
       ...rejection

--- a/src/graphql/review/submitTechnicalReview.graphql
+++ b/src/graphql/review/submitTechnicalReview.graphql
@@ -1,5 +1,5 @@
 mutation submitTechnicalReview(
-  $proposalID: Int!
+  $proposalPK: Int!
   $timeAllocation: Int
   $comment: String
   $publicComment: String
@@ -9,7 +9,7 @@ mutation submitTechnicalReview(
 ) {
   submitTechnicalReview(
     submitTechnicalReviewInput: {
-      proposalID: $proposalID
+      proposalPK: $proposalPK
       timeAllocation: $timeAllocation
       comment: $comment
       publicComment: $publicComment

--- a/src/graphql/review/submitTechnicalReview.graphql
+++ b/src/graphql/review/submitTechnicalReview.graphql
@@ -1,5 +1,5 @@
 mutation submitTechnicalReview(
-  $proposalPK: Int!
+  $proposalPk: Int!
   $timeAllocation: Int
   $comment: String
   $publicComment: String
@@ -9,7 +9,7 @@ mutation submitTechnicalReview(
 ) {
   submitTechnicalReview(
     submitTechnicalReviewInput: {
-      proposalPK: $proposalPK
+      proposalPk: $proposalPk
       timeAllocation: $timeAllocation
       comment: $comment
       publicComment: $publicComment

--- a/src/graphql/review/userWithReviews.graphql
+++ b/src/graphql/review/userWithReviews.graphql
@@ -23,7 +23,7 @@ query userWithReviews(
       proposal {
         primaryKey
         title
-        shortCode
+        proposalId
         call {
           shortCode
         }

--- a/src/graphql/review/userWithReviews.graphql
+++ b/src/graphql/review/userWithReviews.graphql
@@ -21,7 +21,7 @@ query userWithReviews(
       status
       sepID
       proposal {
-        id
+        primaryKey
         title
         shortCode
         call {

--- a/src/graphql/samples/createSample.graphql
+++ b/src/graphql/samples/createSample.graphql
@@ -1,13 +1,13 @@
 mutation createSample(
   $title: String!
   $templateId: Int!
-  $proposalPK: Int!
+  $proposalPk: Int!
   $questionId: String!
 ) {
   createSample(
     title: $title
     templateId: $templateId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
     questionId: $questionId
   ) {
     sample {

--- a/src/graphql/samples/createSample.graphql
+++ b/src/graphql/samples/createSample.graphql
@@ -1,13 +1,13 @@
 mutation createSample(
   $title: String!
   $templateId: Int!
-  $proposalId: Int!
+  $proposalPK: Int!
   $questionId: String!
 ) {
   createSample(
     title: $title
     templateId: $templateId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
     questionId: $questionId
   ) {
     sample {

--- a/src/graphql/samples/fragment.sample.graphql
+++ b/src/graphql/samples/fragment.sample.graphql
@@ -6,6 +6,6 @@ fragment sample on Sample {
   safetyStatus
   safetyComment
   created
-  proposalId
+  proposalPK
   questionId
 }

--- a/src/graphql/samples/fragment.sample.graphql
+++ b/src/graphql/samples/fragment.sample.graphql
@@ -6,6 +6,6 @@ fragment sample on Sample {
   safetyStatus
   safetyComment
   created
-  proposalPK
+  proposalPk
   questionId
 }

--- a/src/graphql/samples/getSamplesByCallId.graphql
+++ b/src/graphql/samples/getSamplesByCallId.graphql
@@ -3,7 +3,7 @@ query getSamplesByCallId($callId: Int!) {
     ...sample
     proposal {
       primaryKey
-      shortCode
+      proposalId
     }
   }
 }

--- a/src/graphql/samples/getSamplesByCallId.graphql
+++ b/src/graphql/samples/getSamplesByCallId.graphql
@@ -2,7 +2,7 @@ query getSamplesByCallId($callId: Int!) {
   samplesByCallId(callId: $callId) {
     ...sample
     proposal {
-      id
+      primaryKey
       shortCode
     }
   }

--- a/src/graphql/samples/getSamplesWithProposalData.graphql
+++ b/src/graphql/samples/getSamplesWithProposalData.graphql
@@ -2,7 +2,7 @@ query getSamplesWithProposalData($filter: SamplesFilter) {
   samples(filter: $filter) {
     ...sample
     proposal {
-      id
+      primaryKey
       shortCode
     }
   }

--- a/src/graphql/samples/getSamplesWithProposalData.graphql
+++ b/src/graphql/samples/getSamplesWithProposalData.graphql
@@ -3,7 +3,7 @@ query getSamplesWithProposalData($filter: SamplesFilter) {
     ...sample
     proposal {
       primaryKey
-      shortCode
+      proposalId
     }
   }
 }

--- a/src/graphql/shipment/createShipment.graphql
+++ b/src/graphql/shipment/createShipment.graphql
@@ -1,5 +1,5 @@
-mutation createShipment($title: String!, $proposalId: Int!) {
-  createShipment(title: $title, proposalId: $proposalId) {
+mutation createShipment($title: String!, $proposalPK: Int!) {
+  createShipment(title: $title, proposalPK: $proposalPK) {
     shipment {
       ...shipment
       questionary {

--- a/src/graphql/shipment/createShipment.graphql
+++ b/src/graphql/shipment/createShipment.graphql
@@ -1,5 +1,5 @@
-mutation createShipment($title: String!, $proposalPK: Int!) {
-  createShipment(title: $title, proposalPK: $proposalPK) {
+mutation createShipment($title: String!, $proposalPk: Int!) {
+  createShipment(title: $title, proposalPk: $proposalPk) {
     shipment {
       ...shipment
       questionary {

--- a/src/graphql/shipment/fragment.shipment.graphql
+++ b/src/graphql/shipment/fragment.shipment.graphql
@@ -1,7 +1,7 @@
 fragment shipment on Shipment {
   id
   title
-  proposalPK
+  proposalPk
   status
   externalRef
   questionaryId

--- a/src/graphql/shipment/fragment.shipment.graphql
+++ b/src/graphql/shipment/fragment.shipment.graphql
@@ -8,6 +8,6 @@ fragment shipment on Shipment {
   creatorId
   created
   proposal {
-    shortCode
+    proposalId
   }
 }

--- a/src/graphql/shipment/fragment.shipment.graphql
+++ b/src/graphql/shipment/fragment.shipment.graphql
@@ -1,7 +1,7 @@
 fragment shipment on Shipment {
   id
   title
-  proposalId
+  proposalPK
   status
   externalRef
   questionaryId

--- a/src/graphql/shipment/updateShipment.graphql
+++ b/src/graphql/shipment/updateShipment.graphql
@@ -1,14 +1,14 @@
 mutation updateShipment(
   $shipmentId: Int!
   $title: String
-  $proposalId: Int
+  $proposalPK: Int
   $status: ShipmentStatus
 ) {
   updateShipment(
     shipmentId: $shipmentId
     title: $title
     status: $status
-    proposalId: $proposalId
+    proposalPK: $proposalPK
   ) {
     rejection {
       ...rejection

--- a/src/graphql/shipment/updateShipment.graphql
+++ b/src/graphql/shipment/updateShipment.graphql
@@ -1,14 +1,14 @@
 mutation updateShipment(
   $shipmentId: Int!
   $title: String
-  $proposalPK: Int
+  $proposalPk: Int
   $status: ShipmentStatus
 ) {
   updateShipment(
     shipmentId: $shipmentId
     title: $title
     status: $status
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
   ) {
     rejection {
       ...rejection

--- a/src/graphql/user/getUserProposals.graphql
+++ b/src/graphql/user/getUserProposals.graphql
@@ -2,7 +2,7 @@ query getUserProposals {
   me {
     proposals {
       primaryKey
-      shortCode
+      proposalId
       title
       status {
         ...proposalStatus

--- a/src/graphql/user/getUserProposals.graphql
+++ b/src/graphql/user/getUserProposals.graphql
@@ -1,7 +1,7 @@
 query getUserProposals {
   me {
     proposals {
-      id
+      primaryKey
       shortCode
       title
       status {

--- a/src/graphql/visit/createVisit.graphql
+++ b/src/graphql/visit/createVisit.graphql
@@ -1,5 +1,5 @@
-mutation createVisit($proposalId: Int!, $team: [Int!]) {
-  createVisit(proposalId: $proposalId, team: $team) {
+mutation createVisit($proposalPK: Int!, $team: [Int!]) {
+  createVisit(proposalPK: $proposalPK, team: $team) {
     visit {
       ...visit
 

--- a/src/graphql/visit/createVisit.graphql
+++ b/src/graphql/visit/createVisit.graphql
@@ -1,5 +1,5 @@
-mutation createVisit($proposalPK: Int!, $team: [Int!]) {
-  createVisit(proposalPK: $proposalPK, team: $team) {
+mutation createVisit($proposalPk: Int!, $team: [Int!]) {
+  createVisit(proposalPk: $proposalPk, team: $team) {
     visit {
       ...visit
 

--- a/src/graphql/visit/fragment.visit.graphql
+++ b/src/graphql/visit/fragment.visit.graphql
@@ -1,6 +1,6 @@
 fragment visit on Visit {
   id
-  proposalPK
+  proposalPk
   status
   questionaryId
   visitorId

--- a/src/graphql/visit/fragment.visit.graphql
+++ b/src/graphql/visit/fragment.visit.graphql
@@ -1,6 +1,6 @@
 fragment visit on Visit {
   id
-  proposalId
+  proposalPK
   status
   questionaryId
   visitorId

--- a/src/graphql/visit/updateVisit.graphql
+++ b/src/graphql/visit/updateVisit.graphql
@@ -2,11 +2,11 @@ mutation updateVisit(
   $visitId: Int!
   $team: [Int!]
   $status: VisitStatus
-  $proposalPK: Int
+  $proposalPk: Int
 ) {
   updateVisit(
     visitId: $visitId
-    proposalPK: $proposalPK
+    proposalPk: $proposalPk
     team: $team
     status: $status
   ) {

--- a/src/graphql/visit/updateVisit.graphql
+++ b/src/graphql/visit/updateVisit.graphql
@@ -2,11 +2,11 @@ mutation updateVisit(
   $visitId: Int!
   $team: [Int!]
   $status: VisitStatus
-  $proposalId: Int
+  $proposalPK: Int
 ) {
   updateVisit(
     visitId: $visitId
-    proposalId: $proposalId
+    proposalPK: $proposalPK
     team: $team
     status: $status
   ) {

--- a/src/hooks/SEP/useSEPProposalData.ts
+++ b/src/hooks/SEP/useSEPProposalData.ts
@@ -5,14 +5,14 @@ import { useDataApi } from 'hooks/common/useDataApi';
 
 export type SepProposalBasics = Pick<
   SepProposal,
-  'proposalPK' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'
+  'proposalPk' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'
 > & {
   proposal: Proposal;
 };
 
 export function useSEPProposalData(
   sepId: number,
-  proposalPK?: number | null
+  proposalPk?: number | null
 ): {
   loading: boolean;
   SEPProposalData: SepProposalBasics | null;
@@ -28,9 +28,9 @@ export function useSEPProposalData(
     let unmounted = false;
     setLoading(true);
 
-    if (proposalPK && sepId) {
+    if (proposalPk && sepId) {
       api()
-        .getSEPProposal({ sepId, proposalPK })
+        .getSEPProposal({ sepId, proposalPk })
         .then((data) => {
           if (unmounted) {
             return;
@@ -48,7 +48,7 @@ export function useSEPProposalData(
     return () => {
       unmounted = true;
     };
-  }, [sepId, api, proposalPK]);
+  }, [sepId, api, proposalPk]);
 
   return { loading, SEPProposalData, setSEPProposalData };
 }

--- a/src/hooks/SEP/useSEPProposalData.ts
+++ b/src/hooks/SEP/useSEPProposalData.ts
@@ -5,14 +5,14 @@ import { useDataApi } from 'hooks/common/useDataApi';
 
 export type SepProposalBasics = Pick<
   SepProposal,
-  'proposalId' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'
+  'proposalPK' | 'sepId' | 'sepTimeAllocation' | 'instrumentSubmitted'
 > & {
   proposal: Proposal;
 };
 
 export function useSEPProposalData(
   sepId: number,
-  proposalId?: number | null
+  proposalPK?: number | null
 ): {
   loading: boolean;
   SEPProposalData: SepProposalBasics | null;
@@ -28,9 +28,9 @@ export function useSEPProposalData(
     let unmounted = false;
     setLoading(true);
 
-    if (proposalId && sepId) {
+    if (proposalPK && sepId) {
       api()
-        .getSEPProposal({ sepId, proposalId })
+        .getSEPProposal({ sepId, proposalPK })
         .then((data) => {
           if (unmounted) {
             return;
@@ -48,7 +48,7 @@ export function useSEPProposalData(
     return () => {
       unmounted = true;
     };
-  }, [sepId, api, proposalId]);
+  }, [sepId, api, proposalPK]);
 
   return { loading, SEPProposalData, setSEPProposalData };
 }

--- a/src/hooks/proposal/useDownloadPDFProposal.ts
+++ b/src/hooks/proposal/useDownloadPDFProposal.ts
@@ -8,8 +8,8 @@ import {
 export function useDownloadPDFProposal() {
   const { prepareDownload } = useContext(DownloadContext);
   const downloadProposalPDF = useCallback(
-    (proposalIds: number[], name: string) => {
-      prepareDownload(PREPARE_DOWNLOAD_TYPE.PDF_PROPOSAL, proposalIds, name);
+    (proposalPKs: number[], name: string) => {
+      prepareDownload(PREPARE_DOWNLOAD_TYPE.PDF_PROPOSAL, proposalPKs, name);
     },
     [prepareDownload]
   );

--- a/src/hooks/proposal/useDownloadPDFProposal.ts
+++ b/src/hooks/proposal/useDownloadPDFProposal.ts
@@ -8,8 +8,8 @@ import {
 export function useDownloadPDFProposal() {
   const { prepareDownload } = useContext(DownloadContext);
   const downloadProposalPDF = useCallback(
-    (proposalPKs: number[], name: string) => {
-      prepareDownload(PREPARE_DOWNLOAD_TYPE.PDF_PROPOSAL, proposalPKs, name);
+    (proposalPks: number[], name: string) => {
+      prepareDownload(PREPARE_DOWNLOAD_TYPE.PDF_PROPOSAL, proposalPks, name);
     },
     [prepareDownload]
   );

--- a/src/hooks/proposal/useDownloadXLSXProposal.ts
+++ b/src/hooks/proposal/useDownloadXLSXProposal.ts
@@ -8,8 +8,8 @@ import {
 export function useDownloadXLSXProposal() {
   const { prepareDownload } = useContext(DownloadContext);
   const downloadProposalXLSX = useCallback(
-    (proposalIds: number[], name: string) => {
-      prepareDownload(PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL, proposalIds, name);
+    (proposalPKs: number[], name: string) => {
+      prepareDownload(PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL, proposalPKs, name);
     },
     [prepareDownload]
   );

--- a/src/hooks/proposal/useDownloadXLSXProposal.ts
+++ b/src/hooks/proposal/useDownloadXLSXProposal.ts
@@ -8,8 +8,8 @@ import {
 export function useDownloadXLSXProposal() {
   const { prepareDownload } = useContext(DownloadContext);
   const downloadProposalXLSX = useCallback(
-    (proposalPKs: number[], name: string) => {
-      prepareDownload(PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL, proposalPKs, name);
+    (proposalPks: number[], name: string) => {
+      prepareDownload(PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL, proposalPks, name);
     },
     [prepareDownload]
   );

--- a/src/hooks/proposal/usePersistProposalModel.ts
+++ b/src/hooks/proposal/usePersistProposalModel.ts
@@ -21,7 +21,7 @@ export function usePersistProposalModel() {
         case 'PROPOSAL_SUBMIT_CLICKED': {
           api('Saved')
             .submitProposal({
-              id: action.proposalPK,
+              id: action.proposalPk,
             })
             .then((result) => {
               const state = getState() as ProposalSubmissionState;

--- a/src/hooks/proposal/usePersistProposalModel.ts
+++ b/src/hooks/proposal/usePersistProposalModel.ts
@@ -21,7 +21,7 @@ export function usePersistProposalModel() {
         case 'PROPOSAL_SUBMIT_CLICKED': {
           api('Saved')
             .submitProposal({
-              id: action.proposalId,
+              id: action.proposalPK,
             })
             .then((result) => {
               const state = getState() as ProposalSubmissionState;

--- a/src/hooks/proposal/usePersistProposalModel.ts
+++ b/src/hooks/proposal/usePersistProposalModel.ts
@@ -21,7 +21,7 @@ export function usePersistProposalModel() {
         case 'PROPOSAL_SUBMIT_CLICKED': {
           api('Saved')
             .submitProposal({
-              id: action.proposalPk,
+              proposalPk: action.proposalPk,
             })
             .then((result) => {
               const state = getState() as ProposalSubmissionState;

--- a/src/hooks/proposal/useProposalData.ts
+++ b/src/hooks/proposal/useProposalData.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { GetProposalQuery } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 
-export function useProposalData(id: number | null | undefined) {
+export function useProposalData(primaryKey: number | null | undefined) {
   const [proposalData, setProposalData] = useState<ProposalData | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -12,10 +12,10 @@ export function useProposalData(id: number | null | undefined) {
   useEffect(() => {
     let unmounted = false;
 
-    if (id) {
+    if (primaryKey) {
       setLoading(true);
       api()
-        .getProposal({ id })
+        .getProposal({ primaryKey })
         .then((data) => {
           if (unmounted) {
             return;
@@ -29,7 +29,7 @@ export function useProposalData(id: number | null | undefined) {
     return () => {
       unmounted = true;
     };
-  }, [id, api]);
+  }, [primaryKey, api]);
 
   return { loading, proposalData, setProposalData };
 }

--- a/src/hooks/proposal/useSubmitProposal.ts
+++ b/src/hooks/proposal/useSubmitProposal.ts
@@ -7,11 +7,11 @@ export function useSubmitProposal() {
 
   const api = useDataApi();
 
-  const submitProposal = async (id: number) => {
+  const submitProposal = async (proposalPk: number) => {
     setIsLoading(true);
 
     return api()
-      .submitProposal({ id })
+      .submitProposal({ proposalPk })
       .then((data) => {
         setIsLoading(false);
 

--- a/src/hooks/proposal/useUserProposals.ts
+++ b/src/hooks/proposal/useUserProposals.ts
@@ -7,7 +7,7 @@ export function useUserProposals(role = UserRole.USER) {
   const [proposals, setProposals] = useState<
     Pick<
       Proposal,
-      | 'id'
+      | 'primaryKey'
       | 'shortCode'
       | 'title'
       | 'publicStatus'
@@ -40,7 +40,7 @@ export function useUserProposals(role = UserRole.USER) {
           if (data.proposalsView) {
             setProposals(
               data.proposalsView.map((proposalView) => ({
-                id: proposalView.id,
+                primaryKey: proposalView.primaryKey,
                 shortCode: proposalView.shortCode,
                 title: proposalView.title,
                 notified: proposalView.notified,

--- a/src/hooks/proposal/useUserProposals.ts
+++ b/src/hooks/proposal/useUserProposals.ts
@@ -8,7 +8,7 @@ export function useUserProposals(role = UserRole.USER) {
     Pick<
       Proposal,
       | 'primaryKey'
-      | 'shortCode'
+      | 'proposalId'
       | 'title'
       | 'publicStatus'
       | 'statusId'
@@ -41,7 +41,7 @@ export function useUserProposals(role = UserRole.USER) {
             setProposals(
               data.proposalsView.map((proposalView) => ({
                 primaryKey: proposalView.primaryKey,
-                shortCode: proposalView.shortCode,
+                proposalId: proposalView.proposalId,
                 title: proposalView.title,
                 notified: proposalView.notified,
                 submitted: proposalView.submitted,

--- a/src/hooks/proposalBooking/useProposalBookingsScheduledEvents.ts
+++ b/src/hooks/proposalBooking/useProposalBookingsScheduledEvents.ts
@@ -10,7 +10,7 @@ export type ProposalScheduledEvent = Pick<
   ScheduledEvent,
   'startsAt' | 'endsAt'
 > & {
-  proposal: Pick<Proposal, 'id' | 'title' | 'shortCode'> & {
+  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'> & {
     visits: VisitFragment[] | null;
   };
 };
@@ -57,7 +57,7 @@ export function useProposalBookingsScheduledEvents({
                   startsAt: scheduledEvent.startsAt,
                   endsAt: scheduledEvent.endsAt,
                   proposal: {
-                    id: proposal.id,
+                    primaryKey: proposal.primaryKey,
                     title: proposal.title,
                     shortCode: proposal.shortCode,
                     visits: proposal.visits,

--- a/src/hooks/proposalBooking/useProposalBookingsScheduledEvents.ts
+++ b/src/hooks/proposalBooking/useProposalBookingsScheduledEvents.ts
@@ -10,7 +10,7 @@ export type ProposalScheduledEvent = Pick<
   ScheduledEvent,
   'startsAt' | 'endsAt'
 > & {
-  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'> & {
+  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'> & {
     visits: VisitFragment[] | null;
   };
 };
@@ -59,7 +59,7 @@ export function useProposalBookingsScheduledEvents({
                   proposal: {
                     primaryKey: proposal.primaryKey,
                     title: proposal.title,
-                    shortCode: proposal.shortCode,
+                    proposalId: proposal.proposalId,
                     visits: proposal.visits,
                   },
                 });

--- a/src/hooks/sample/useProposalSamples.ts
+++ b/src/hooks/sample/useProposalSamples.ts
@@ -3,28 +3,28 @@ import { useEffect, useState } from 'react';
 import { useDataApi } from 'hooks/common/useDataApi';
 import { SampleWithQuestionaryStatus } from 'models/Sample';
 
-export function useProposalSamples(proposalPK: number | null) {
+export function useProposalSamples(proposalPk: number | null) {
   const [samples, setSamples] = useState<SampleWithQuestionaryStatus[]>([]);
 
   const [loadingSamples, setLoadingSamples] = useState(false);
   const api = useDataApi();
 
   useEffect(() => {
-    if (!proposalPK) {
+    if (!proposalPk) {
       setSamples([]);
 
       return;
     }
     setLoadingSamples(true);
     api()
-      .getSamplesWithQuestionaryStatus({ filter: { proposalPK } })
+      .getSamplesWithQuestionaryStatus({ filter: { proposalPk } })
       .then((data) => {
         if (data.samples) {
           setSamples(data.samples);
         }
         setLoadingSamples(false);
       });
-  }, [api, proposalPK]);
+  }, [api, proposalPk]);
 
   return { samples, loadingSamples, setSamples };
 }

--- a/src/hooks/sample/useProposalSamples.ts
+++ b/src/hooks/sample/useProposalSamples.ts
@@ -3,28 +3,28 @@ import { useEffect, useState } from 'react';
 import { useDataApi } from 'hooks/common/useDataApi';
 import { SampleWithQuestionaryStatus } from 'models/Sample';
 
-export function useProposalSamples(proposalId: number | null) {
+export function useProposalSamples(proposalPK: number | null) {
   const [samples, setSamples] = useState<SampleWithQuestionaryStatus[]>([]);
 
   const [loadingSamples, setLoadingSamples] = useState(false);
   const api = useDataApi();
 
   useEffect(() => {
-    if (!proposalId) {
+    if (!proposalPK) {
       setSamples([]);
 
       return;
     }
     setLoadingSamples(true);
     api()
-      .getSamplesWithQuestionaryStatus({ filter: { proposalId } })
+      .getSamplesWithQuestionaryStatus({ filter: { proposalPK } })
       .then((data) => {
         if (data.samples) {
           setSamples(data.samples);
         }
         setLoadingSamples(false);
       });
-  }, [api, proposalId]);
+  }, [api, proposalPK]);
 
   return { samples, loadingSamples, setSamples };
 }

--- a/src/models/ProposalSubmissionState.ts
+++ b/src/models/ProposalSubmissionState.ts
@@ -12,7 +12,7 @@ export type ProposalSubsetSubmission = Pick<
   | 'status'
   | 'users'
   | 'title'
-  | 'shortCode'
+  | 'proposalId'
   | 'callId'
   | 'questionaryId'
   | 'submitted'

--- a/src/models/ProposalSubmissionState.ts
+++ b/src/models/ProposalSubmissionState.ts
@@ -5,7 +5,7 @@ import { QuestionarySubmissionState } from './QuestionarySubmissionState';
 
 export type ProposalSubsetSubmission = Pick<
   Proposal,
-  | 'id'
+  | 'primaryKey'
   | 'abstract'
   | 'proposer'
   | 'questionary'

--- a/src/models/QuestionarySubmissionState.ts
+++ b/src/models/QuestionarySubmissionState.ts
@@ -32,7 +32,7 @@ export type Event =
   | { type: 'PROPOSAL_MODIFIED'; proposal: Partial<ProposalSubsetSubmission> }
   | { type: 'PROPOSAL_CREATED'; proposal: ProposalSubsetSubmission }
   | { type: 'PROPOSAL_LOADED'; proposal: ProposalSubsetSubmission }
-  | { type: 'PROPOSAL_SUBMIT_CLICKED'; proposalPK: number }
+  | { type: 'PROPOSAL_SUBMIT_CLICKED'; proposalPk: number }
   | { type: 'SHIPMENT_CREATED'; shipment: ShipmentExtended }
   | { type: 'SHIPMENT_LOADED'; shipment: ShipmentExtended }
   | { type: 'SHIPMENT_MODIFIED'; shipment: Partial<ShipmentExtended> }

--- a/src/models/QuestionarySubmissionState.ts
+++ b/src/models/QuestionarySubmissionState.ts
@@ -32,7 +32,7 @@ export type Event =
   | { type: 'PROPOSAL_MODIFIED'; proposal: Partial<ProposalSubsetSubmission> }
   | { type: 'PROPOSAL_CREATED'; proposal: ProposalSubsetSubmission }
   | { type: 'PROPOSAL_LOADED'; proposal: ProposalSubsetSubmission }
-  | { type: 'PROPOSAL_SUBMIT_CLICKED'; proposalId: number }
+  | { type: 'PROPOSAL_SUBMIT_CLICKED'; proposalPK: number }
   | { type: 'SHIPMENT_CREATED'; shipment: ShipmentExtended }
   | { type: 'SHIPMENT_LOADED'; shipment: ShipmentExtended }
   | { type: 'SHIPMENT_MODIFIED'; shipment: Partial<ShipmentExtended> }

--- a/src/models/Review.ts
+++ b/src/models/Review.ts
@@ -1,7 +1,7 @@
 export class Review {
   constructor(
     public id: number,
-    public proposalPK: number,
+    public proposalPk: number,
     public userID: number,
     public comment: string,
     public grade: number,

--- a/src/models/Review.ts
+++ b/src/models/Review.ts
@@ -1,7 +1,7 @@
 export class Review {
   constructor(
     public id: number,
-    public proposalID: number,
+    public proposalPK: number,
     public userID: number,
     public comment: string,
     public grade: number,

--- a/src/models/ShipmentSubmissionState.ts
+++ b/src/models/ShipmentSubmissionState.ts
@@ -12,6 +12,6 @@ export interface ShipmentSubmissionState extends QuestionarySubmissionState {
 
 export interface ShipmentBasisFormikData {
   title: string;
-  proposalId: number;
+  proposalPK: number;
   samples: SampleFragment[];
 }

--- a/src/models/ShipmentSubmissionState.ts
+++ b/src/models/ShipmentSubmissionState.ts
@@ -12,6 +12,6 @@ export interface ShipmentSubmissionState extends QuestionarySubmissionState {
 
 export interface ShipmentBasisFormikData {
   title: string;
-  proposalPK: number;
+  proposalPk: number;
   samples: SampleFragment[];
 }

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -49,7 +49,7 @@ export const getProposalStatus = (
 
 export const fromProposalToProposalView = (proposal: Proposal) => {
   return {
-    id: proposal.id,
+    primaryKey: proposal.primaryKey,
     title: proposal.title,
     status: proposal.status?.name || '',
     statusId: proposal.status?.id || 1,

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -56,7 +56,7 @@ export const fromProposalToProposalView = (proposal: Proposal) => {
     statusName: proposal.status?.name || '',
     statusDescription: proposal.status?.description || '',
     submitted: proposal.submitted,
-    shortCode: proposal.shortCode,
+    proposalId: proposal.proposalId,
     rankOrder: proposal.sepMeetingDecision?.rankOrder,
     finalStatus: getTranslation(proposal.finalStatus as ResourceId),
     timeAllocation: proposal.technicalReview?.timeAllocation || null,


### PR DESCRIPTION
## Description

refactor: Renaming shortcode to proposal ID and proposal ID to proposal primary key

## Motivation and Context

In some places we call the 6 digit identifier as proposal ID but in others shortcode. In system it is called a shortcode, but people often refer it to as the ID. 

Because people call shortcode ID this task is to rename the shortcode to proposal_id and existing id to primary_key


## Fixes

SWAP-1629

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/339
https://github.com/UserOfficeProject/user-office-scheduler-frontend/pull/47
https://github.com/UserOfficeProject/user-office-scheduler-backend/pull/40
