### PR TITLE
Making equipment optional

### DIFF
--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -2546,7 +2546,7 @@ export type ScheduledEvent = {
   scheduledBy: Maybe<User>;
   description: Maybe<Scalars['String']>;
   instrument: Maybe<Instrument>;
-  equipmentId: Scalars['Int'];
+  equipmentId: Maybe<Scalars['Int']>;
   equipments: Array<EquipmentWithAssignmentStatus>;
   equipmentAssignmentStatus: Maybe<EquipmentAssignmentStatus>;
   proposalBooking: Maybe<ProposalBooking>;


### PR DESCRIPTION
## Description

Mark equipment ID optional because it has been marked as such in the user-office-scheduler-backend