### PR TITLE
feat: Add accent color to the color palette and use it mainly for icons

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,9 @@
   "settings": {
     "react": {
       "version": "detect"
+    },
+    "jest": {
+      "version": "detect"
     }
   },
   "plugins": [
@@ -97,7 +100,7 @@
     ],
     "@typescript-eslint/ban-ts-comment": "warn",
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/no-non-null-assertion":"off", // already checked by typescript, no need to duplicate
+    "@typescript-eslint/no-non-null-assertion": "off", // already checked by typescript, no need to duplicate
     "jest/no-export": "off", // rule not implemented properly, rule should only restrict exporting tests
     "unused-imports/no-unused-imports-ts": 2
   }

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -48,7 +48,14 @@ const closeModal = () => {
 };
 
 const finishedLoading = () => {
-  cy.get('[role="progressbar"]').should('not.exist');
+  cy.get('[role="progressbar"]')
+    .should('not.exist')
+    .get('[data-cy="loading"]')
+    .should('not.exist')
+    .get('[data-cy="UO-loader"]')
+    .should('not.exist')
+    .get('.MuiPaper-root [role="progressbar"]')
+    .should('not.exist');
 };
 
 function presentationMode() {

--- a/src/components/AppToolbar/AppToolbar.tsx
+++ b/src/components/AppToolbar/AppToolbar.tsx
@@ -112,9 +112,9 @@ const AppToolbar: React.FC<AppToolbarProps> = ({ open, handleDrawerOpen }) => {
           <MenuIcon />
         </IconButton>
         {(!isTabletOrMobile || !isPortraitMode) && logo && (
-          <div className={'header-logo-container'}>
+          <Link className={'header-logo-container'} to="/">
             <img src={logo} alt="logo" className={'header-logo'} />
-          </div>
+          </Link>
         )}
         {(!isTabletOrMobile || !isPortraitMode) && (
           <Typography

--- a/src/components/common/UOLoader.tsx
+++ b/src/components/common/UOLoader.tsx
@@ -22,6 +22,7 @@ const UOLoader: React.FC<
   return (
     <CircularProgress
       className={clsx({ [classes.button]: buttonSized })}
+      data-cy="UO-loader"
       {...props}
     />
   );

--- a/src/context/FeatureContextProvider.tsx
+++ b/src/context/FeatureContextProvider.tsx
@@ -1,7 +1,6 @@
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import React from 'react';
 
-import UOLoader from 'components/common/UOLoader';
 import { Feature, FeatureId } from 'generated/sdk';
 import { useFeatures } from 'hooks/admin/useFeatures';
 
@@ -32,11 +31,7 @@ export const FeatureContextProvider: React.FC = (props) => {
   const classes = useStyles();
 
   if (loadingFeatures) {
-    return (
-      <div className={classes.loader}>
-        <UOLoader size={40} />
-      </div>
-    );
+    return <div className={classes.loader}>Loading...</div>;
   }
 
   const featuresMap = features?.reduce(function (featuresMap, feature) {

--- a/src/context/FeatureContextProvider.tsx
+++ b/src/context/FeatureContextProvider.tsx
@@ -31,7 +31,11 @@ export const FeatureContextProvider: React.FC = (props) => {
   const classes = useStyles();
 
   if (loadingFeatures) {
-    return <div className={classes.loader}>Loading...</div>;
+    return (
+      <div className={classes.loader} data-cy="loading">
+        Loading...
+      </div>
+    );
   }
 
   const featuresMap = features?.reduce(function (featuresMap, feature) {

--- a/src/context/SettingsContextProvider.tsx
+++ b/src/context/SettingsContextProvider.tsx
@@ -1,7 +1,6 @@
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import React from 'react';
 
-import UOLoader from 'components/common/UOLoader';
 import { Settings, SettingsId } from 'generated/sdk';
 import { useSettings } from 'hooks/admin/useSettings';
 
@@ -32,11 +31,7 @@ export const SettingsContextProvider: React.FC = (props) => {
   const classes = useStyles();
 
   if (loadingSettings) {
-    return (
-      <div className={classes.loader}>
-        <UOLoader size={40} />
-      </div>
-    );
+    return <div className={classes.loader}>Loading...</div>;
   }
 
   const settingsMap = settings?.reduce(function (settingsMap, settings) {

--- a/src/context/SettingsContextProvider.tsx
+++ b/src/context/SettingsContextProvider.tsx
@@ -31,7 +31,11 @@ export const SettingsContextProvider: React.FC = (props) => {
   const classes = useStyles();
 
   if (loadingSettings) {
-    return <div className={classes.loader}>Loading...</div>;
+    return (
+      <div className={classes.loader} data-cy="loading">
+        Loading...
+      </div>
+    );
   }
 
   const settingsMap = settings?.reduce(function (settingsMap, settings) {

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -640,6 +640,7 @@ export type Mutation = {
   setInstrumentAvailabilityTime: SuccessResponseWrap;
   submitInstrument: SuccessResponseWrap;
   administrationProposal: ProposalResponseWrap;
+  cloneProposals: ProposalsResponseWrap;
   updateProposal: ProposalResponseWrap;
   addProposalWorkflowStatus: ProposalWorkflowConnectionResponseWrap;
   addStatusChangingEventsToConnection: ProposalStatusChangingEventResponseWrap;
@@ -698,7 +699,6 @@ export type Mutation = {
   addTechnicalReview: TechnicalReviewResponseWrap;
   applyPatches: PrepareDbResponseWrap;
   checkExternalToken: CheckExternalTokenWrap;
-  cloneProposals: ProposalsResponseWrap;
   cloneSample: SampleResponseWrap;
   cloneTemplate: TemplateResponseWrap;
   createProposal: ProposalResponseWrap;
@@ -868,6 +868,11 @@ export type MutationAdministrationProposalArgs = {
   statusId?: Maybe<Scalars['Int']>;
   managementTimeAllocation?: Maybe<Scalars['Int']>;
   managementDecisionSubmitted?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type MutationCloneProposalsArgs = {
+  cloneProposalsInput: CloneProposalsInput;
 };
 
 
@@ -1278,11 +1283,6 @@ export type MutationAddTechnicalReviewArgs = {
 
 export type MutationCheckExternalTokenArgs = {
   externalToken: Scalars['String'];
-};
-
-
-export type MutationCloneProposalsArgs = {
-  cloneProposalsInput: CloneProposalsInput;
 };
 
 
@@ -2657,6 +2657,7 @@ export enum SettingsId {
   PROFILE_PAGE_LINK = 'PROFILE_PAGE_LINK',
   PALETTE_PRIMARY_DARK = 'PALETTE_PRIMARY_DARK',
   PALETTE_PRIMARY_MAIN = 'PALETTE_PRIMARY_MAIN',
+  PALETTE_PRIMARY_ACCENT = 'PALETTE_PRIMARY_ACCENT',
   PALETTE_PRIMARY_LIGHT = 'PALETTE_PRIMARY_LIGHT',
   PALETTE_PRIMARY_CONTRAST = 'PALETTE_PRIMARY_CONTRAST',
   PALETTE_SECONDARY_DARK = 'PALETTE_SECONDARY_DARK',

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -640,7 +640,6 @@ export type Mutation = {
   setInstrumentAvailabilityTime: SuccessResponseWrap;
   submitInstrument: SuccessResponseWrap;
   administrationProposal: ProposalResponseWrap;
-  cloneProposals: ProposalsResponseWrap;
   updateProposal: ProposalResponseWrap;
   addProposalWorkflowStatus: ProposalWorkflowConnectionResponseWrap;
   addStatusChangingEventsToConnection: ProposalStatusChangingEventResponseWrap;
@@ -699,6 +698,7 @@ export type Mutation = {
   addTechnicalReview: TechnicalReviewResponseWrap;
   applyPatches: PrepareDbResponseWrap;
   checkExternalToken: CheckExternalTokenWrap;
+  cloneProposals: ProposalsResponseWrap;
   cloneSample: SampleResponseWrap;
   cloneTemplate: TemplateResponseWrap;
   createProposal: ProposalResponseWrap;
@@ -868,11 +868,6 @@ export type MutationAdministrationProposalArgs = {
   statusId?: Maybe<Scalars['Int']>;
   managementTimeAllocation?: Maybe<Scalars['Int']>;
   managementDecisionSubmitted?: Maybe<Scalars['Boolean']>;
-};
-
-
-export type MutationCloneProposalsArgs = {
-  cloneProposalsInput: CloneProposalsInput;
 };
 
 
@@ -1283,6 +1278,11 @@ export type MutationAddTechnicalReviewArgs = {
 
 export type MutationCheckExternalTokenArgs = {
   externalToken: Scalars['String'];
+};
+
+
+export type MutationCloneProposalsArgs = {
+  cloneProposalsInput: CloneProposalsInput;
 };
 
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 :root {
   --PALETTE_PRIMARY_DARK: #303f9f;
   --PALETTE_PRIMARY_MAIN: #3f51b5;
+  --PALETTE_PRIMARY_ACCENT: #0000008a;
   --PALETTE_PRIMARY_LIGHT: #7986cb;
   --PALETTE_PRIMARY_CONTRAST: #fff;
   --PALETTE_SECONDARY_DARK: #c51162;
@@ -52,68 +53,77 @@ code {
   background-color: rgba(0, 0, 0, 0.3);
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   color: var(--PALETTE_PRIMARY_DARK);
 }
 
 /* Drawer icons */
 .MuiDrawer-root .MuiListItemIcon-root {
-  color: var(--PALETTE_PRIMARY_MAIN);
+  color: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Drawer close icon */
 .MuiDrawer-root .MuiIconButton-root {
-  color: var(--PALETTE_PRIMARY_MAIN);
+  color: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Table row buttons */
 .MuiTable-root .MuiTableRow-root .MuiIconButton-root:not(.Mui-disabled) {
-  color: var(--PALETTE_PRIMARY_MAIN);
+  color: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Table search icon */
-.MuiGrid-root .MuiToolbar-root .MuiInputAdornment-positionStart:not(.Mui-disabled) {
-  color: var(--PALETTE_PRIMARY_MAIN);
+.MuiGrid-root
+  .MuiToolbar-root
+  .MuiInputAdornment-positionStart:not(.Mui-disabled) {
+  color: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Table show columns icon */
 .MuiGrid-root .MuiToolbar-root .MuiIconButton-root:not(.Mui-disabled) {
-  color: var(--PALETTE_PRIMARY_MAIN);
+  color: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Table drop-down icons */
 .MuiGrid-root .MuiFormControl-root .MuiInput-root > svg {
-  fill: var(--PALETTE_PRIMARY_MAIN);
+  fill: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Table search clear button, date pickers */
 .MuiFormControl-root .MuiInputAdornment-positionEnd button:not(.Mui-disabled) {
-  color: var(--PALETTE_PRIMARY_MAIN);
+  color: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Table pagination icons */
 .MuiTablePagination-input > svg {
-  fill: var(--PALETTE_PRIMARY_MAIN);
+  fill: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Drop-down icons */
 .MuiSvgIcon-root.MuiSelect-icon {
-  fill: var(--PALETTE_PRIMARY_MAIN);
+  fill: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* 'Box' search icon */
-.MuiBox-root .MuiToolbar-root .MuiInputAdornment-positionStart:not(.Mui-disabled) {
-  color: var(--PALETTE_PRIMARY_MAIN);
+.MuiBox-root
+  .MuiToolbar-root
+  .MuiInputAdornment-positionStart:not(.Mui-disabled) {
+  color: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* 'Box' buttons */
 .MuiBox-root .MuiIconButton-root:not(.Mui-disabled) {
-  color: var(--PALETTE_PRIMARY_MAIN);
+  color: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Role icons */
 .MuiList-root .MuiMenuItem-root:not(.Mui-disabled) svg {
-  fill: var(--PALETTE_PRIMARY_MAIN);
+  fill: var(--PALETTE_PRIMARY_ACCENT);
 }
 
 /* Logo image - ensures min 1/4 of the height is padding */
@@ -158,22 +168,22 @@ h1, h2, h3, h4, h5, h6 {
   background-color: var(--PALETTE_PRIMARY_LIGHT);
 }
 
-.MuiSnackbar-root [class*="SnackbarItem-variantSuccess"] {
+.MuiSnackbar-root [class*='SnackbarItem-variantSuccess'] {
   background-color: var(--PALETTE_SUCCESS_MAIN);
   color: var(--PALETTE_PRIMARY_CONTRAST);
 }
 
-.MuiSnackbar-root [class*="SnackbarItem-variantError"] {
+.MuiSnackbar-root [class*='SnackbarItem-variantError'] {
   background-color: var(--PALETTE_ERROR_MAIN);
   color: var(--PALETTE_PRIMARY_CONTRAST);
 }
 
-.MuiSnackbar-root [class*="SnackbarItem-variantWarning"] {
+.MuiSnackbar-root [class*='SnackbarItem-variantWarning'] {
   background-color: var(--PALETTE_WARNING_MAIN);
   color: var(--PALETTE_PRIMARY_CONTRAST);
 }
 
-.MuiSnackbar-root [class*="SnackbarItem-variantInformation"] {
+.MuiSnackbar-root [class*='SnackbarItem-variantInformation'] {
   background-color: var(--PALETTE_INFO_MAIN);
   color: var(--PALETTE_SECONDARY_CONTRAST);
 }


### PR DESCRIPTION
## Description

1. Add accent color to the palette that is used mainly as a color for icons.
2. Improve some e2e tests.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1711

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/374


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
