### PR TITLE
Improve user experience when cloning sample

### DIFF
--- a/cypress/integration/templates.ts
+++ b/cypress/integration/templates.ts
@@ -1215,7 +1215,7 @@ context('Template tests', () => {
     });
   });
 
-  it('should not let you create circular dependency chain', () => {
+  it('Should not let you create circular dependency chain', () => {
     cy.login('officer');
 
     cy.navigateToTemplatesSubmenu('Proposal');

--- a/src/components/common/withHandleEnter.tsx
+++ b/src/components/common/withHandleEnter.tsx
@@ -6,18 +6,19 @@ interface WithHandleEnterProps {
   onEnter: (value: string) => void;
 }
 /**
- * Returns modified WrapperComponent which will has onEnter callback
- * @param WrappedComponent
+ * Returns modified TextField which will has onEnter callback,
+ * which will be called when RETURN is pressed
+ * @param WrappedTextField
  */
 const withHandleEnter = <P extends TextFieldProps>(
-  WrappedComponent: React.ComponentType<P>
+  WrappedTextField: React.ComponentType<P>
 ): React.FC<P & WithHandleEnterProps> => {
   return function withHandleEnterComponent({
     onEnter,
     ...props
   }: WithHandleEnterProps) {
     return (
-      <WrappedComponent
+      <WrappedTextField
         {...(props as P)}
         onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
           if (event.key.toLowerCase() === 'enter') {

--- a/src/components/common/withHandleEnter.tsx
+++ b/src/components/common/withHandleEnter.tsx
@@ -6,7 +6,7 @@ interface WithHandleEnterProps {
   onEnter: (value: string) => void;
 }
 /**
- * Returns modified TextField which will has onEnter callback,
+ * Returns modified TextField with onEnter callback,
  * which will be called when RETURN is pressed
  * @param WrappedTextField
  */

--- a/src/components/common/withHandleEnter.tsx
+++ b/src/components/common/withHandleEnter.tsx
@@ -1,0 +1,32 @@
+import { TextFieldProps } from '@material-ui/core';
+import React, { KeyboardEvent } from 'react';
+
+interface WithHandleEnterProps {
+  onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => false | undefined;
+  onEnter: (value: string) => void;
+}
+/**
+ * Returns modified WrapperComponent which will has onEnter callback
+ * @param WrappedComponent
+ */
+const withHandleEnter = <P extends TextFieldProps>(
+  WrappedComponent: React.ComponentType<P>
+): React.FC<P & WithHandleEnterProps> => {
+  return function withHandleEnterComponent({
+    onEnter,
+    ...props
+  }: WithHandleEnterProps) {
+    return (
+      <WrappedComponent
+        {...(props as P)}
+        onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+          if (event.key.toLowerCase() === 'enter') {
+            onEnter(event.currentTarget.value);
+          }
+        }}
+      />
+    );
+  };
+};
+
+export default withHandleEnter;

--- a/src/components/questionary/questionaryComponents/QuestionnairesListItem.tsx
+++ b/src/components/questionary/questionaryComponents/QuestionnairesListItem.tsx
@@ -68,6 +68,7 @@ export function QuestionnairesListItem(props: {
           edge="start"
           aria-label="clone"
           data-cy="clone"
+          title="Copy"
           onClick={(e: MouseEvent) => {
             e.stopPropagation();
             props.onCloneClick(props.record);
@@ -81,6 +82,7 @@ export function QuestionnairesListItem(props: {
           edge="end"
           aria-label="delete"
           data-cy="delete"
+          title="Remove"
           onClick={(e: MouseEvent) => {
             e.stopPropagation();
             props.onDeleteClick(props.record);

--- a/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
+++ b/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
@@ -20,6 +20,7 @@ import { SampleCore } from 'models/questionary/sample/SampleCore';
 import { SampleWithQuestionary } from 'models/questionary/sample/SampleWithQuestionary';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 import withConfirm, { WithConfirmType } from 'utils/withConfirm';
+import withPrompt, { WithPromptType } from 'utils/withPrompt';
 
 import {
   QuestionnairesList,
@@ -72,12 +73,13 @@ type QuestionaryComponentSampleDeclarationProps = {
   answer: Answer;
   formikProps: FormikProps<Record<string, unknown>>;
   confirm: WithConfirmType;
+  prompt: WithPromptType;
 };
 
 function QuestionaryComponentSampleDeclaration(
   props: QuestionaryComponentSampleDeclarationProps
 ) {
-  const { answer, confirm } = props;
+  const { answer, confirm, prompt } = props;
   const answerId = answer.question.id;
   const config = answer.config as SubTemplateConfig;
   const { state } = useContext(QuestionaryContext) as ProposalContextType;
@@ -97,9 +99,9 @@ function QuestionaryComponentSampleDeclaration(
   return (
     <Field name={answerId}>
       {({ field, form }: FieldProps<SampleWithQuestionary[]>) => {
-        const copySample = (id: number) =>
+        const copySample = (id: number, title: string) =>
           api()
-            .cloneSample({ sampleId: id })
+            .cloneSample({ sampleId: id, title: title })
             .then((response) => {
               const clonedSample = response.cloneSample.sample;
               if (clonedSample) {
@@ -145,10 +147,9 @@ function QuestionaryComponentSampleDeclaration(
                 })();
               }}
               onCloneClick={(item) => {
-                confirm(() => copySample(item.id), {
-                  title: 'Copy Sample',
-                  description:
-                    'This action will copy the sample and all data associated with it',
+                prompt((answer) => copySample(item.id, answer), {
+                  question: 'Title',
+                  initialAnswer: `Copy of ${item.label}`,
                 })();
               }}
               onAddNewClick={() => {
@@ -237,4 +238,4 @@ function QuestionaryComponentSampleDeclaration(
   );
 }
 
-export default withConfirm(QuestionaryComponentSampleDeclaration);
+export default withConfirm(withPrompt(QuestionaryComponentSampleDeclaration));

--- a/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
+++ b/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
@@ -149,7 +149,7 @@ function QuestionaryComponentSampleDeclaration(
               onCloneClick={(item) => {
                 prompt((answer) => copySample(item.id, answer), {
                   question: 'Title',
-                  initialAnswer: `Copy of ${item.label}`,
+                  prefilledAnswer: `Copy of ${item.label}`,
                 })();
               }}
               onAddNewClick={() => {

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -1318,6 +1318,7 @@ export type MutationCheckExternalTokenArgs = {
 
 
 export type MutationCloneSampleArgs = {
+  title?: Maybe<Scalars['String']>;
   sampleId: Scalars['Int'];
 };
 
@@ -5331,6 +5332,7 @@ export type UpdateRiskAssessmentMutation = (
 
 export type CloneSampleMutationVariables = Exact<{
   sampleId: Scalars['Int'];
+  title?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -9445,8 +9447,8 @@ export const UpdateRiskAssessmentDocument = gql`
 ${SampleFragmentDoc}
 ${RejectionFragmentDoc}`;
 export const CloneSampleDocument = gql`
-    mutation cloneSample($sampleId: Int!) {
-  cloneSample(sampleId: $sampleId) {
+    mutation cloneSample($sampleId: Int!, $title: String) {
+  cloneSample(sampleId: $sampleId, title: $title) {
     sample {
       ...sample
       questionary {

--- a/src/graphql/samples/cloneSample.graphql
+++ b/src/graphql/samples/cloneSample.graphql
@@ -1,5 +1,5 @@
-mutation cloneSample($sampleId: Int!) {
-  cloneSample(sampleId: $sampleId) {
+mutation cloneSample($sampleId: Int!, $title: String) {
+  cloneSample(sampleId: $sampleId, title: $title) {
     sample {
       ...sample
       questionary {

--- a/src/utils/withPrompt.tsx
+++ b/src/utils/withPrompt.tsx
@@ -1,0 +1,89 @@
+import { DialogContent, TextField } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import React, { useCallback, useState } from 'react';
+
+import withHandleEnter from 'components/common/withHandleEnter';
+
+import { FunctionType } from './utilTypes';
+
+const defaultOptions: Options = {
+  question: '',
+  initialAnswer: '',
+  okBtnLabel: 'OK',
+  cancelBtnLabel: 'Cancel',
+};
+
+const TextFieldWithHandleEnter = withHandleEnter(TextField);
+
+const withPrompt = <T extends Record<string, unknown>>(
+  WrappedComponent: React.ComponentType<T>
+) => {
+  return function WithPromptComponent(props: Omit<T, 'prompt'>): JSX.Element {
+    const [onPrompt, setOnPrompt] = useState<((answer: string) => void) | null>(
+      null
+    );
+    const [options, setOptions] = useState(defaultOptions);
+    const [answer, setAnswer] = useState<string>(options.initialAnswer);
+
+    const { question, okBtnLabel, cancelBtnLabel } = options;
+    const handleCancel = useCallback(() => {
+      setOnPrompt(null);
+    }, []);
+    const handleOk = useCallback(() => {
+      if (onPrompt) {
+        onPrompt(answer);
+      }
+      setOnPrompt(null);
+    }, [onPrompt, answer]);
+
+    const prompt = useCallback(
+      (onPrompt, options: Options) => (): void => {
+        setOnPrompt(() => onPrompt);
+        setOptions({ ...defaultOptions, ...options });
+        setAnswer(options.initialAnswer);
+      },
+      []
+    );
+
+    return (
+      <>
+        <WrappedComponent {...(props as T)} prompt={prompt} />
+        <Dialog fullWidth open={!!onPrompt} onClose={handleCancel}>
+          <DialogContent>
+            <TextFieldWithHandleEnter
+              label={question}
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              fullWidth
+              autoFocus
+              onEnter={handleOk}
+            />
+            <DialogActions>
+              <Button onClick={handleCancel}>{cancelBtnLabel}</Button>
+              <Button onClick={handleOk} color="primary" data-cy="prompt-ok">
+                {okBtnLabel}
+              </Button>
+            </DialogActions>
+          </DialogContent>
+        </Dialog>
+      </>
+    );
+  };
+};
+
+interface Options {
+  question: string;
+  initialAnswer: string;
+  okBtnLabel: string;
+  cancelBtnLabel: string;
+  dialogProps?: Record<string, unknown>;
+}
+
+export type WithPromptType = (
+  callback: (answer: string) => void,
+  params: Partial<Options>
+) => FunctionType;
+
+export default withPrompt;

--- a/src/utils/withPrompt.tsx
+++ b/src/utils/withPrompt.tsx
@@ -10,7 +10,7 @@ import { FunctionType } from './utilTypes';
 
 const defaultOptions: Options = {
   question: '',
-  initialAnswer: '',
+  prefilledAnswer: '',
   okBtnLabel: 'OK',
   cancelBtnLabel: 'Cancel',
 };
@@ -33,7 +33,7 @@ const withPrompt = <T extends Record<string, unknown>>(
       null
     );
     const [options, setOptions] = useState(defaultOptions);
-    const [answer, setAnswer] = useState<string>(options.initialAnswer);
+    const [answer, setAnswer] = useState<string>(options.prefilledAnswer);
 
     const { question, okBtnLabel, cancelBtnLabel } = options;
     const handleCancel = useCallback(() => {
@@ -50,7 +50,7 @@ const withPrompt = <T extends Record<string, unknown>>(
       (onPrompt, options: Options) => (): void => {
         setOnPrompt(() => onPrompt);
         setOptions({ ...defaultOptions, ...options });
-        setAnswer(options.initialAnswer);
+        setAnswer(options.prefilledAnswer);
       },
       []
     );
@@ -84,7 +84,7 @@ const withPrompt = <T extends Record<string, unknown>>(
 
 interface Options {
   question: string;
-  initialAnswer: string;
+  prefilledAnswer: string;
   okBtnLabel: string;
   cancelBtnLabel: string;
   dialogProps?: Record<string, unknown>;

--- a/src/utils/withPrompt.tsx
+++ b/src/utils/withPrompt.tsx
@@ -61,6 +61,7 @@ const withPrompt = <T extends Record<string, unknown>>(
         <Dialog fullWidth open={!!onPrompt} onClose={handleCancel}>
           <DialogContent>
             <TextFieldWithHandleEnter
+              id="prompt-input"
               label={question}
               value={answer}
               onChange={(e) => setAnswer(e.target.value)}

--- a/src/utils/withPrompt.tsx
+++ b/src/utils/withPrompt.tsx
@@ -17,6 +17,14 @@ const defaultOptions: Options = {
 
 const TextFieldWithHandleEnter = withHandleEnter(TextField);
 
+/**
+ * withPrompt allows to easily use prompt UI dialog for single string question input.
+ * Usage:
+ * prompt((answer) => console.log(answer), {
+ *   question: 'Enter some text',
+ * })()
+ * @param WrappedComponent
+ */
 const withPrompt = <T extends Record<string, unknown>>(
   WrappedComponent: React.ComponentType<T>
 ) => {


### PR DESCRIPTION
## Description

This PR aims to improve the user experience when cloning sample
![Peek 2021-09-14 13-41](https://user-images.githubusercontent.com/58165815/133251435-02d18a83-a039-4bc1-be6d-ad83119fb920.gif)


## Motivation and Context

Currently, when cloning a sample it clones it with the title 'Copy of <original title>". Most often the user will then click the item to rename it.

With this change when the user wants to copy a sample the prompt is presented asking to enter the new title of the sample.

## How Has This Been Tested

- [x] E2E

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/406

