### PR TITLE
feat: add long title and description to call

### DIFF
--- a/src/components/call/CallGeneralInfo.tsx
+++ b/src/components/call/CallGeneralInfo.tsx
@@ -141,6 +141,7 @@ const CallGeneralInfo: React.FC<{
         type="text"
         component={TextField}
         margin="normal"
+        inputProps={{ maxLength: '20' }}
         fullWidth
         required
         data-cy="short-code"
@@ -277,6 +278,28 @@ const CallGeneralInfo: React.FC<{
         label="Allocation time unit"
         items={allocationTimeUnitOptions as Option[]}
         InputProps={{ 'data-cy': 'allocation-time-unit' }}
+      />
+      <Field
+        name="title"
+        label="Title (public)"
+        id="title-input"
+        type="text"
+        component={TextField}
+        margin="normal"
+        fullWidth
+        inputProps={{ maxLength: '100' }}
+        data-cy="title"
+      />
+      <Field
+        name="description"
+        label="Description (public)"
+        id="description-input"
+        type="text"
+        component={TextField}
+        margin="normal"
+        multiline
+        fullWidth
+        data-cy="description"
       />
     </>
   );

--- a/src/components/call/CallNotificationAndCycleInfo.tsx
+++ b/src/components/call/CallNotificationAndCycleInfo.tsx
@@ -82,6 +82,7 @@ const CallCycleInfo: React.FC = () => {
         required
         fullWidth
         data-cy="cycle-comment"
+        inputProps={{ maxLength: '100' }}
       />
     </>
   );

--- a/src/components/call/CallReviewsInfo.tsx
+++ b/src/components/call/CallReviewsInfo.tsx
@@ -85,6 +85,7 @@ const CallReviewAndNotification: React.FC = () => {
         margin="normal"
         fullWidth
         required
+        inputProps={{ maxLength: '100' }}
         data-cy="survey-comment"
       />
     </>

--- a/src/components/call/CreateUpdateCall.tsx
+++ b/src/components/call/CreateUpdateCall.tsx
@@ -68,6 +68,8 @@ const CreateUpdateCall: React.FC<CreateUpdateCallProps> = ({ call, close }) => {
         proposalWorkflowId: '',
         templateId: '',
         allocationTimeUnit: AllocationTimeUnits.DAY,
+        title: '',
+        description: '',
       };
 
   const closeModal = (error: string | null | undefined, callToReturn: Call) => {

--- a/src/components/proposal/ProposalChooseCall.tsx
+++ b/src/components/proposal/ProposalChooseCall.tsx
@@ -63,7 +63,7 @@ const ProposalChooseCall: React.FC<ProposalChooseCallProps> = ({
             const daysRemainingText = getDaysRemainingText(daysRemainingNum);
 
             const header =
-              call.title === null ? (
+              call.title === null || call.title === '' ? (
                 <Typography variant="h6" component="h3">
                   {call.shortCode}
                 </Typography>
@@ -90,10 +90,10 @@ const ProposalChooseCall: React.FC<ProposalChooseCallProps> = ({
                         )} ${daysRemainingText}`}
                       </Typography>
                       <Typography component="div">
-                        {call.cycleComment}
+                        {call.description}
                       </Typography>
                       <Typography component="div">
-                        {call.description}
+                        {call.cycleComment}
                       </Typography>
                     </Fragment>
                   }

--- a/src/components/proposal/ProposalChooseCall.tsx
+++ b/src/components/proposal/ProposalChooseCall.tsx
@@ -62,6 +62,17 @@ const ProposalChooseCall: React.FC<ProposalChooseCallProps> = ({
             const daysRemainingNum = daysRemaining(new Date(call.endCall));
             const daysRemainingText = getDaysRemainingText(daysRemainingNum);
 
+            const header =
+              call.title === null ? (
+                <Typography variant="h6" component="h3">
+                  {call.shortCode}
+                </Typography>
+              ) : (
+                <Typography variant="h6" component="h3">
+                  {call.title} <small> ({call.shortCode}) </small>
+                </Typography>
+              );
+
             return (
               <ListItem
                 button
@@ -70,20 +81,19 @@ const ProposalChooseCall: React.FC<ProposalChooseCallProps> = ({
                 divider={true}
               >
                 <ListItemText
-                  primary={
-                    <Typography variant="h6" component="h3">
-                      {call.shortCode}
-                    </Typography>
-                  }
+                  primary={header}
                   secondary={
                     <Fragment>
-                      <Typography component="span" className={classes.date}>
+                      <Typography component="div" className={classes.date}>
                         {`Application deadline: ${formatDate(
                           call.endCall
                         )} ${daysRemainingText}`}
                       </Typography>
-                      <Typography component="span">
+                      <Typography component="div">
                         {call.cycleComment}
+                      </Typography>
+                      <Typography component="div">
+                        {call.description}
                       </Typography>
                     </Fragment>
                   }

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -175,6 +175,8 @@ export type Call = {
   proposalWorkflowId: Maybe<Scalars['Int']>;
   allocationTimeUnit: AllocationTimeUnits;
   templateId: Scalars['Int'];
+  title: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   instruments: Array<InstrumentWithAvailabilityTime>;
   proposalWorkflow: Maybe<ProposalWorkflow>;
   template: Template;
@@ -242,6 +244,8 @@ export type CreateCallInput = {
   allocationTimeUnit: AllocationTimeUnits;
   proposalWorkflowId: Scalars['Int'];
   templateId: Scalars['Int'];
+  title?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
 };
 
 export type CreateProposalStatusInput = {
@@ -3031,6 +3035,8 @@ export type UpdateCallInput = {
   callReviewEnded?: Maybe<Scalars['Int']>;
   callSEPReviewEnded?: Maybe<Scalars['Int']>;
   templateId: Scalars['Int'];
+  title?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
 };
 
 export type UpdateProposalStatusInput = {
@@ -4010,6 +4016,8 @@ export type CreateCallMutationVariables = Exact<{
   referenceNumberFormat?: Maybe<Scalars['String']>;
   proposalWorkflowId: Scalars['Int'];
   templateId: Scalars['Int'];
+  title?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -4049,7 +4057,7 @@ export type DeleteCallMutation = (
 
 export type CallFragment = (
   { __typename?: 'Call' }
-  & Pick<Call, 'id' | 'shortCode' | 'startCall' | 'endCall' | 'startReview' | 'endReview' | 'startSEPReview' | 'endSEPReview' | 'startNotify' | 'endNotify' | 'startCycle' | 'endCycle' | 'cycleComment' | 'surveyComment' | 'referenceNumberFormat' | 'proposalWorkflowId' | 'templateId' | 'allocationTimeUnit' | 'proposalCount'>
+  & Pick<Call, 'id' | 'shortCode' | 'startCall' | 'endCall' | 'startReview' | 'endReview' | 'startSEPReview' | 'endSEPReview' | 'startNotify' | 'endNotify' | 'startCycle' | 'endCycle' | 'cycleComment' | 'surveyComment' | 'referenceNumberFormat' | 'proposalWorkflowId' | 'templateId' | 'allocationTimeUnit' | 'proposalCount' | 'title' | 'description'>
   & { instruments: Array<(
     { __typename?: 'InstrumentWithAvailabilityTime' }
     & Pick<InstrumentWithAvailabilityTime, 'id' | 'name' | 'shortCode' | 'description' | 'availabilityTime' | 'submitted'>
@@ -4144,6 +4152,8 @@ export type UpdateCallMutationVariables = Exact<{
   referenceNumberFormat?: Maybe<Scalars['String']>;
   proposalWorkflowId: Scalars['Int'];
   templateId: Scalars['Int'];
+  title?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -7455,6 +7465,8 @@ export const CallFragmentDoc = gql`
     isArchived
   }
   proposalCount
+  title
+  description
 }
     ${BasicUserDetailsFragmentDoc}`;
 export const CoreTechnicalReviewFragmentDoc = gql`
@@ -8466,9 +8478,9 @@ export const AssignInstrumentsToCallDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const CreateCallDocument = gql`
-    mutation createCall($shortCode: String!, $startCall: DateTime!, $endCall: DateTime!, $startReview: DateTime!, $endReview: DateTime!, $startSEPReview: DateTime, $endSEPReview: DateTime, $startNotify: DateTime!, $endNotify: DateTime!, $startCycle: DateTime!, $endCycle: DateTime!, $cycleComment: String!, $surveyComment: String!, $allocationTimeUnit: AllocationTimeUnits!, $referenceNumberFormat: String, $proposalWorkflowId: Int!, $templateId: Int!) {
+    mutation createCall($shortCode: String!, $startCall: DateTime!, $endCall: DateTime!, $startReview: DateTime!, $endReview: DateTime!, $startSEPReview: DateTime, $endSEPReview: DateTime, $startNotify: DateTime!, $endNotify: DateTime!, $startCycle: DateTime!, $endCycle: DateTime!, $cycleComment: String!, $surveyComment: String!, $allocationTimeUnit: AllocationTimeUnits!, $referenceNumberFormat: String, $proposalWorkflowId: Int!, $templateId: Int!, $title: String, $description: String) {
   createCall(
-    createCallInput: {shortCode: $shortCode, startCall: $startCall, endCall: $endCall, startReview: $startReview, endReview: $endReview, startSEPReview: $startSEPReview, endSEPReview: $endSEPReview, startNotify: $startNotify, endNotify: $endNotify, startCycle: $startCycle, endCycle: $endCycle, cycleComment: $cycleComment, surveyComment: $surveyComment, allocationTimeUnit: $allocationTimeUnit, referenceNumberFormat: $referenceNumberFormat, proposalWorkflowId: $proposalWorkflowId, templateId: $templateId}
+    createCallInput: {shortCode: $shortCode, startCall: $startCall, endCall: $endCall, startReview: $startReview, endReview: $endReview, startSEPReview: $startSEPReview, endSEPReview: $endSEPReview, startNotify: $startNotify, endNotify: $endNotify, startCycle: $startCycle, endCycle: $endCycle, cycleComment: $cycleComment, surveyComment: $surveyComment, allocationTimeUnit: $allocationTimeUnit, referenceNumberFormat: $referenceNumberFormat, proposalWorkflowId: $proposalWorkflowId, templateId: $templateId, title: $title, description: $description}
   ) {
     rejection {
       ...rejection
@@ -8532,9 +8544,9 @@ export const RemoveAssignedInstrumentFromCallDocument = gql`
 }
     ${RejectionFragmentDoc}`;
 export const UpdateCallDocument = gql`
-    mutation updateCall($id: Int!, $shortCode: String!, $startCall: DateTime!, $endCall: DateTime!, $startReview: DateTime!, $endReview: DateTime!, $startSEPReview: DateTime, $endSEPReview: DateTime, $startNotify: DateTime!, $endNotify: DateTime!, $startCycle: DateTime!, $endCycle: DateTime!, $cycleComment: String!, $surveyComment: String!, $allocationTimeUnit: AllocationTimeUnits!, $referenceNumberFormat: String, $proposalWorkflowId: Int!, $templateId: Int!) {
+    mutation updateCall($id: Int!, $shortCode: String!, $startCall: DateTime!, $endCall: DateTime!, $startReview: DateTime!, $endReview: DateTime!, $startSEPReview: DateTime, $endSEPReview: DateTime, $startNotify: DateTime!, $endNotify: DateTime!, $startCycle: DateTime!, $endCycle: DateTime!, $cycleComment: String!, $surveyComment: String!, $allocationTimeUnit: AllocationTimeUnits!, $referenceNumberFormat: String, $proposalWorkflowId: Int!, $templateId: Int!, $title: String, $description: String) {
   updateCall(
-    updateCallInput: {id: $id, shortCode: $shortCode, startCall: $startCall, endCall: $endCall, startReview: $startReview, endReview: $endReview, startSEPReview: $startSEPReview, endSEPReview: $endSEPReview, startNotify: $startNotify, endNotify: $endNotify, startCycle: $startCycle, endCycle: $endCycle, cycleComment: $cycleComment, surveyComment: $surveyComment, allocationTimeUnit: $allocationTimeUnit, referenceNumberFormat: $referenceNumberFormat, proposalWorkflowId: $proposalWorkflowId, templateId: $templateId}
+    updateCallInput: {id: $id, shortCode: $shortCode, startCall: $startCall, endCall: $endCall, startReview: $startReview, endReview: $endReview, startSEPReview: $startSEPReview, endSEPReview: $endSEPReview, startNotify: $startNotify, endNotify: $endNotify, startCycle: $startCycle, endCycle: $endCycle, cycleComment: $cycleComment, surveyComment: $surveyComment, allocationTimeUnit: $allocationTimeUnit, referenceNumberFormat: $referenceNumberFormat, proposalWorkflowId: $proposalWorkflowId, templateId: $templateId, title: $title, description: $description}
   ) {
     rejection {
       ...rejection

--- a/src/graphql/call/createCall.graphql
+++ b/src/graphql/call/createCall.graphql
@@ -16,6 +16,8 @@ mutation createCall(
   $referenceNumberFormat: String
   $proposalWorkflowId: Int!
   $templateId: Int!
+  $title: String
+  $description: String
 ) {
   createCall(
     createCallInput: {
@@ -36,6 +38,8 @@ mutation createCall(
       referenceNumberFormat: $referenceNumberFormat
       proposalWorkflowId: $proposalWorkflowId
       templateId: $templateId
+      title: $title
+      description: $description
     }
   ) {
     rejection {

--- a/src/graphql/call/fragment.call.graphql
+++ b/src/graphql/call/fragment.call.graphql
@@ -39,4 +39,6 @@ fragment call on Call {
     isArchived
   }
   proposalCount
+  title
+  description
 }

--- a/src/graphql/call/updateCall.graphql
+++ b/src/graphql/call/updateCall.graphql
@@ -17,6 +17,8 @@ mutation updateCall(
   $referenceNumberFormat: String
   $proposalWorkflowId: Int!
   $templateId: Int!
+  $title: String
+  $description: String
 ) {
   updateCall(
     updateCallInput: {
@@ -38,6 +40,8 @@ mutation updateCall(
       referenceNumberFormat: $referenceNumberFormat
       proposalWorkflowId: $proposalWorkflowId
       templateId: $templateId
+      title: $title
+      description: $description
     }
   ) {
     rejection {


### PR DESCRIPTION
Refs UserOfficeProject/stfc-user-office-project#202

## Description

Adds a title and description to a call to provide users with additional context to the calls that they're applying for.

**Does the cycle comment need to be _required_?** Could we make this optional?

### Call editor

Add optional fields for title and description to the call. Description is a multiline entry.
![image](https://user-images.githubusercontent.com/13658288/134035693-89d7bf39-57ca-4c3a-a18c-f9315f27a032.png)

This also limits the lengths of input to match the database restrictions in the front-end for a _call_ for _short code_, _survey comment_, and _cycle comment_.

### Facility user

If a title and description have been specified, the call card will show these with primary precedence:
![image](https://user-images.githubusercontent.com/13658288/134033925-3685f06f-78ae-45fe-9f66-20c5c7a11d8e.png)

If a title and description haven't been specified, the call card will show the short code with primary precedence and will now show any description:
![image](https://user-images.githubusercontent.com/13658288/134034329-0a5a1f4f-3356-46f6-a585-493fc76da636.png)

## Motivation and Context

Refs UserOfficeProject/stfc-user-office-project#202

As shown in the first _Facility user_ screenshot, our titles and descriptions of _calls_ can exceed what the existing fields could support.

## How Has This Been Tested

 - Tested manually in the frontend with and without the Title and Description shown.
 - Ran all of the e2e tests locally.
 - Ran the unit tests locally.

## Fixes

Closes UserOfficeProject/stfc-user-office-project#202

## Depends on

Depends on https://github.com/UserOfficeProject/user-office-backend/pull/410/

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [x] All relevant doc has been updated

