### PR TITLE
Added external auth to use a query string

### DIFF
--- a/src/components/user/ExternalAuth.tsx
+++ b/src/components/user/ExternalAuth.tsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
+import queryString from 'query-string';
 import React, { useContext, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { SettingsContext } from 'context/SettingsContextProvider';
 import { UserContext } from 'context/UserContextProvider';
@@ -19,7 +21,12 @@ type ExternalAuthProps = PropTypes.InferProps<typeof ExternalAuthPropTypes>;
 const ExternalAuth: React.FC<ExternalAuthProps> = ({ match }) => {
   const { token, handleLogin } = useContext(UserContext);
   const unauthorizedApi = useUnauthorizedApi();
-  const sessionId: string = match.params.sessionId;
+  const { search } = useLocation();
+  const values = queryString.parse(search);
+  const sessionId: string = !!values.sessionid
+    ? values.sessionid.toString()
+    : match.params.sessionId;
+  console.log(sessionId);
 
   const isFirstRun = useRef<boolean>(true);
 
@@ -45,13 +52,14 @@ const ExternalAuth: React.FC<ExternalAuthProps> = ({ match }) => {
           window.location.href = '/';
         } else {
           if (EXTERNAL_AUTH_LOGIN_URL) {
-            window.location.href = EXTERNAL_AUTH_LOGIN_URL;
+            // window.location.href = EXTERNAL_AUTH_LOGIN_URL;
+            return <p>Redirected back {sessionId}</p>;
           }
         }
       });
   }, [token, handleLogin, sessionId, unauthorizedApi, EXTERNAL_AUTH_LOGIN_URL]);
 
-  return <p>Logging in with external service...</p>;
+  return <p>Logging in with external service... SessionID: {sessionId}</p>;
 };
 
 ExternalAuth.propTypes = ExternalAuthPropTypes;


### PR DESCRIPTION
Closes UserOfficeProject/stfc-user-office-project#198

## Description

When auth redirects it encodes the sessionID as a query string, not in the URL. I have added the functionality to extract the query string if it exists with external-auth. We should standardise this to use one method but currently, we using both methods. 

One thing I am not entirely pleased with is that since the parameter in external auth is required and app.ts only uses the external auth route if a sessionID is in the URL I am currently passing a "dummy" string to satisfy these constraints. So the redirect URL from auth would be:
https://devproposal.facilities.rl.ac.uk/external-auth/sessionId?sessionid=<token>

We could change this but it would require more work.

BisAppSetting Branch: stfc-user-office-project-198-STFC-auth-redirect
Docker orchestration PR:
