### PR TITLE
SWAP-1954-searching-by-firstname

### DIFF
--- a/cypress/integration/SEP_ProposalReviewsAndMeetingComponents.ts
+++ b/cypress/integration/SEP_ProposalReviewsAndMeetingComponents.ts
@@ -165,7 +165,7 @@ context(
         text: 'SEP secretary assigned successfully',
       });
 
-      cy.get('[title="Add Member"]').click();
+      cy.get('[data-cy="add-participant-button"]').click();
 
       cy.finishedLoading();
 

--- a/cypress/integration/generalSeps.ts
+++ b/cypress/integration/generalSeps.ts
@@ -401,7 +401,7 @@ context('General scientific evaluation panel tests', () => {
 
     cy.contains('Members').click();
 
-    cy.get('[title="Add Member"]').click();
+    cy.get('[data-cy="add-participant-button"]').click();
 
     cy.finishedLoading();
 

--- a/src/components/SEP/Members/SEPMembers.tsx
+++ b/src/components/SEP/Members/SEPMembers.tsx
@@ -1,4 +1,5 @@
 import MaterialTable from '@material-table/core';
+import { Button } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
 import makeStyles from '@material-ui/core/styles/makeStyles';
@@ -10,6 +11,7 @@ import Person from '@material-ui/icons/Person';
 import PersonAdd from '@material-ui/icons/PersonAdd';
 import React, { useState, useContext } from 'react';
 
+import { ActionButtonContainer } from 'components/common/ActionButtonContainer';
 import { useCheckAccess } from 'components/common/Can';
 import UOLoader from 'components/common/UOLoader';
 import ParticipantModal from 'components/proposal/ParticipantModal';
@@ -202,17 +204,6 @@ const SEPMembers: React.FC<SEPMembersProps> = ({
 
   const AddPersonIcon = (): JSX.Element => <PersonAdd data-cy="add-member" />;
 
-  const tableActions = hasAccessRights
-    ? [
-        {
-          icon: AddPersonIcon,
-          isFreeAction: true,
-          tooltip: 'Add Member',
-          onClick: (): void => setOpen(true),
-        },
-      ]
-    : [];
-
   const alreadySelectedMembers = (SEPReviewersData ?? []).map(
     ({ userId }) => userId
   );
@@ -404,8 +395,20 @@ const SEPMembers: React.FC<SEPMembersProps> = ({
               options={{
                 search: false,
               }}
-              actions={tableActions}
             />
+            {hasAccessRights && (
+              <ActionButtonContainer>
+                <Button
+                  variant="contained"
+                  onClick={() => setOpen(true)}
+                  data-cy="add-participant-button"
+                  color="primary"
+                  startIcon={<AddPersonIcon />}
+                >
+                  Add reviewers
+                </Button>
+              </ActionButtonContainer>
+            )}
           </Grid>
         </Grid>
       </>

--- a/src/components/user/PeopleTable.tsx
+++ b/src/components/user/PeopleTable.tsx
@@ -70,8 +70,9 @@ const useStyles = makeStyles({
 });
 
 const columns = [
-  { title: 'Name', field: 'firstname' },
-  { title: 'Surname', field: 'lastname' },
+  { title: 'Firstname', field: 'firstname' },
+  { title: 'Lastname', field: 'lastname' },
+  { title: 'Preferred name', field: 'preferredname' },
   { title: 'Organisation', field: 'organisation' },
 ];
 

--- a/src/components/user/ProposalsPeopleTable.tsx
+++ b/src/components/user/ProposalsPeopleTable.tsx
@@ -133,8 +133,9 @@ const useStyles = makeStyles({
 });
 
 const columns = [
-  { title: 'Name', field: 'firstname' },
+  { title: 'Fristname', field: 'firstname' },
   { title: 'Surname', field: 'lastname' },
+  { title: 'Preferred name', field: 'preferredname' },
   { title: 'Organisation', field: 'organisation' },
 ];
 

--- a/src/components/visit/CreateVisitRegistration.tsx
+++ b/src/components/visit/CreateVisitRegistration.tsx
@@ -24,6 +24,7 @@ function createRegistrationStub(
     user: {
       firstname: '',
       lastname: '',
+      preferredname: '',
       id: userId,
       created: new Date(),
       organisation: '',

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -134,6 +134,7 @@ export type BasicUserDetails = {
   organisation: Scalars['String'];
   placeholder: Maybe<Scalars['Boolean']>;
   position: Scalars['String'];
+  preferredname: Maybe<Scalars['String']>;
 };
 
 export type BasicUserDetailsResponseWrap = {
@@ -3630,7 +3631,7 @@ export type GetSepMembersQuery = (
       & Pick<Role, 'id' | 'shortCode' | 'title'>
     )>, user: (
       { __typename?: 'BasicUserDetails' }
-      & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation' | 'position' | 'placeholder' | 'created'>
+      & BasicUserDetailsFragment
     ) }
   )>> }
 );
@@ -3768,7 +3769,7 @@ export type GetSepReviewersQuery = (
       & Pick<Role, 'id' | 'shortCode' | 'title'>
     )>, user: (
       { __typename?: 'BasicUserDetails' }
-      & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation' | 'position' | 'placeholder' | 'created'>
+      & BasicUserDetailsFragment
     ) }
   )>> }
 );
@@ -7405,7 +7406,7 @@ export type DeleteUserMutation = (
 
 export type BasicUserDetailsFragment = (
   { __typename?: 'BasicUserDetails' }
-  & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation' | 'position' | 'created' | 'placeholder'>
+  & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'preferredname' | 'organisation' | 'position' | 'created' | 'placeholder'>
 );
 
 export type GetBasicUserDetailsQueryVariables = Exact<{
@@ -8063,6 +8064,7 @@ export const BasicUserDetailsFragmentDoc = gql`
   id
   firstname
   lastname
+  preferredname
   organisation
   position
   created
@@ -8678,17 +8680,11 @@ export const GetSepMembersDocument = gql`
       title
     }
     user {
-      id
-      firstname
-      lastname
-      organisation
-      position
-      placeholder
-      created
+      ...basicUserDetails
     }
   }
 }
-    `;
+    ${BasicUserDetailsFragmentDoc}`;
 export const GetSepProposalDocument = gql`
     query getSEPProposal($sepId: Int!, $proposalPk: Int!) {
   sepProposal(sepId: $sepId, proposalPk: $proposalPk) {
@@ -8829,17 +8825,11 @@ export const GetSepReviewersDocument = gql`
       title
     }
     user {
-      id
-      firstname
-      lastname
-      organisation
-      position
-      placeholder
-      created
+      ...basicUserDetails
     }
   }
 }
-    `;
+    ${BasicUserDetailsFragmentDoc}`;
 export const GetSePsDocument = gql`
     query getSEPs($filter: String!, $active: Boolean) {
   seps(filter: $filter, active: $active) {

--- a/src/graphql/SEP/getSEPMembers.graphql
+++ b/src/graphql/SEP/getSEPMembers.graphql
@@ -8,13 +8,7 @@ query getSEPMembers($sepId: Int!) {
       title
     }
     user {
-      id
-      firstname
-      lastname
-      organisation
-      position
-      placeholder
-      created
+      ...basicUserDetails
     }
   }
 }

--- a/src/graphql/SEP/getSEPReviewers.graphql
+++ b/src/graphql/SEP/getSEPReviewers.graphql
@@ -8,13 +8,7 @@ query getSEPReviewers($sepId: Int!) {
       title
     }
     user {
-      id
-      firstname
-      lastname
-      organisation
-      position
-      placeholder
-      created
+      ...basicUserDetails
     }
   }
 }

--- a/src/graphql/user/fragment.basicUserInformation.graphql
+++ b/src/graphql/user/fragment.basicUserInformation.graphql
@@ -2,6 +2,7 @@ fragment basicUserDetails on BasicUserDetails {
   id
   firstname
   lastname
+  preferredname
   organisation
   position
   created


### PR DESCRIPTION
## Description

fix: Add preferred name to BasicUserDetails to be able to show and search in the people table. Also modified the Add reviewers button in the sep members to follow the general design language

## Motivation and Context

Previously the people table was a bit confusing because it was using preferred name if there is one for the first name if not then first name was used. If you try to search by first name it wasn't showing the correct results on the frontend. Now we have both first name and preferred name in the table.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1954

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/459

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
