### PR TITLE
Make email not found text specific for if email invite exist

### DIFF
--- a/src/components/user/ProposalsPeopleTable.tsx
+++ b/src/components/user/ProposalsPeopleTable.tsx
@@ -345,6 +345,9 @@ const ProposalsPeopleTable: React.FC<PeopleTableProps> = (props) => {
   );
 
   const currentPage = (query.offset as number) / (query.first as number);
+  const emailSearchText = isEmailInviteEnabled
+    ? 'Please check the spelling and if the user has registered with us. If not found, the user can be added through email invite.'
+    : 'Please check the spelling and if the user has registered with us or has the correct privacy settings to be found by this search.';
 
   return (
     <Formik
@@ -422,8 +425,7 @@ const ProposalsPeopleTable: React.FC<PeopleTableProps> = (props) => {
                 }
               >
                 <AlertTitle>We cannot find that email</AlertTitle>
-                Please check the spelling and if the user has registered with us
-                or has the correct privacy settings to be found by this search.
+                {emailSearchText}
               </Alert>
             )}
           </div>


### PR DESCRIPTION
## Description

The current text when searching for a person via email indicates that privacy settings exist, this is not the case at ESS. This PR will make the text different depending on if email invite is available .

## Motivation and Context

To not confuse ESS users

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
