### PR TITLE
fix: validation for spinner arrows in firefox

### DIFF
--- a/src/components/questionary/questionaryComponents/NumberInput/QuestionaryComponentNumberInput.tsx
+++ b/src/components/questionary/questionaryComponents/NumberInput/QuestionaryComponentNumberInput.tsx
@@ -126,6 +126,12 @@ export function QuestionaryComponentNumber(props: BasicComponentProps) {
               setStateValue(newValue);
               if (isEventFromAutoComplete(event)) {
                 onComplete(newValue);
+              } else {
+                /* Firefox's number spinner arrows don't grant focus
+                (see https://bugzilla.mozilla.org/show_bug.cgi?id=1012818)
+                but we use loss of focus (blur) to update component state.
+                Using blur means we don't update on every keystroke. */
+                event.target.focus();
               }
             }}
             onBlur={() => onComplete(stateValue)}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Prevents the "This is a required field" validation error appearing on required number inputs in firefox when they were set using only the up/down spinner arrows.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing in Chrome and Firefox on Windows 10 by clearing a required number input, attempting to save, and then setting the number via the spinner arrows. This would previously trigger the bug, but it no longer does so.

I've also tried typing numbers in the middle of the text field to ensure that the focus() call doesn't force the caret to the end or start of the textbox mid typing.

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
UserOfficeProject/stfc-user-office-project#281

## Changes

<!--- What types of changes does your code introduce? In what place? -->
The bug was caused by the input's onBlur handler not being called, as this would normally update the component's state once it's no longer focused after being edited.
However, long standing issue in firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1012818 means that unlike chromium based browsers, firefox doesn't grant focus when spinner arrows are used, so it has no focus to lose and the blur event can't be called. To work around this we can simply force focus on the input whenever the arrows trigger a change event.

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
