### PR TITLE
refactor: remove unused commissioning booking type from scheduler

### DIFF
--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -2607,7 +2607,6 @@ export type SaveSepMeetingDecisionInput = {
 };
 
 export enum ScheduledEventBookingType {
-  COMMISSIONING = 'COMMISSIONING',
   EQUIPMENT = 'EQUIPMENT',
   MAINTENANCE = 'MAINTENANCE',
   SHUTDOWN = 'SHUTDOWN',


### PR DESCRIPTION
## Description

Removing booking type that is not used at all for now but was there from the beginning.
