### PR TITLE
fix: hide warning if local contact defined

### DIFF
--- a/src/components/shipments/DeclareShipments.tsx
+++ b/src/components/shipments/DeclareShipments.tsx
@@ -106,10 +106,12 @@ function DeclareShipments({
           <li>Post the shipment</li>
         </ol>
       </Typography>
-      <Alert severity="warning" hidden={!hasLocalContact}>
-        Shipment declarations are not possible until the local contact has been
-        assigned to your scheduled event
-      </Alert>
+      {!hasLocalContact && (
+        <Alert severity="warning">
+          Shipment declarations are not possible until the local contact has
+          been assigned to your scheduled event
+        </Alert>
+      )}
       <QuestionnairesList
         addButtonLabel="Add Shipment"
         data={shipments.map(shipmentToListRow) ?? []}


### PR DESCRIPTION
## Description

Hide the warning that local contact needs to be defined if the contact is defined

## How Has This Been Tested

- [x] Manual tests

## Changes

DeclareShipments.tsx

## Depends on

N/A
