### PR TITLE
feat: Add user information to error log

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -114,12 +114,21 @@ const Routes: React.FC<RouteProps> = () => {
 };
 
 class App extends React.Component {
-  static getDerivedStateFromError(): void {
+  state = { errorUserInformation: '' };
+  static getDerivedStateFromError() {
     // Update state so the next render will show the fallback UI.
+    const user = localStorage.getItem('user');
+    const errorUserInformation = {
+      id: user ? JSON.parse(user).id : 'Not logged in',
+      currentRole: localStorage.getItem('currentRole'),
+    };
+
     localStorage.removeItem('token');
     localStorage.removeItem('currentRole');
     localStorage.removeItem('user');
     localStorage.removeItem('expToken');
+
+    return { errorUserInformation };
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
@@ -128,6 +137,7 @@ class App extends React.Component {
       errorMessage = JSON.stringify({
         error: error.toString(),
         errorInfo: errorInfo.componentStack.toString(),
+        user: this.state.errorUserInformation,
       });
     } catch (e) {
       errorMessage = 'Exception while preparing error message';


### PR DESCRIPTION
## Description

Currently when an error is reported from the frontend it does not contain what user had the error and role. This PR adds this information to the error sent

## Motivation and Context

Make debugging easier

## How Has This Been Tested

locally

## Fixes

swap-2367

## Changes

App.tsx


