### PR TITLE
fix: SEP reviewer should only see list of proposals he/she can review

### DIFF
--- a/cypress/integration/SEP.ts
+++ b/cypress/integration/SEP.ts
@@ -1,10 +1,6 @@
 import faker from 'faker';
 
-import {
-  ProposalEndStatus,
-  TechnicalReviewStatus,
-  UserRole,
-} from '../../src/generated/sdk';
+import { TechnicalReviewStatus } from '../../src/generated/sdk';
 import initialDBData from '../support/initialDBData';
 
 const sepMembers = {
@@ -1364,26 +1360,8 @@ context('SEP meeting components tests', () => {
       cy.visit('/');
     });
 
-    it('SEP Reviewer should be able to see reviews even if he/she is not direct reviewer but only member of the SEP', () => {
+    it('SEP Reviewer should not be able to see reviews he/she is not a direct reviewer', () => {
       cy.get('main table tbody').contains('No records to display');
-
-      cy.get('[data-cy="reviewer-filter"]').click();
-
-      cy.get('[data-value="ALL"]').click();
-
-      cy.finishedLoading();
-
-      cy.contains(proposal1.proposalTitle)
-        .parent()
-        .find('[aria-label="Grade proposal"]')
-        .click();
-
-      cy.finishedLoading();
-
-      cy.contains(proposal1.proposalTitle);
-      cy.get('[role="dialog"]').contains('Grade');
-      cy.get('textarea[id="comment"]').should('exist');
-      cy.get('button[type="submit"]').should('exist');
     });
   });
 });

--- a/cypress/integration/SEP.ts
+++ b/cypress/integration/SEP.ts
@@ -1,6 +1,10 @@
 import faker from 'faker';
 
-import { TechnicalReviewStatus } from '../../src/generated/sdk';
+import {
+  ProposalEndStatus,
+  TechnicalReviewStatus,
+  UserRole,
+} from '../../src/generated/sdk';
 import initialDBData from '../support/initialDBData';
 
 const sepMembers = {

--- a/src/components/review/ProposalTableReviewer.tsx
+++ b/src/components/review/ProposalTableReviewer.tsx
@@ -35,9 +35,6 @@ import ProposalReviewContent, {
   PROPOSAL_MODAL_TAB_NAMES,
 } from './ProposalReviewContent';
 import ProposalReviewModal from './ProposalReviewModal';
-import ReviewerFilterComponent, {
-  defaultReviewerQueryFilter,
-} from './ReviewerFilter';
 import ReviewStatusFilter, {
   defaultReviewStatusQueryFilter,
 } from './ReviewStatusFilter';
@@ -98,7 +95,6 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
     reviewStatus: defaultReviewStatusQueryFilter,
     reviewModal: NumberParam,
     modalTab: NumberParam,
-    reviewer: defaultReviewerQueryFilter,
   });
 
   const [selectedProposals, setSelectedProposals] = useState<
@@ -121,7 +117,7 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
       callId: selectedCallId,
       instrumentId: selectedInstrumentId,
       status: getFilterStatus(urlQueryParams.reviewStatus),
-      reviewer: getFilterReviewer(urlQueryParams.reviewer),
+      reviewer: ReviewerFilter.YOU,
     });
 
   const handleStatusFilterChange = (reviewStatus: ReviewStatus) => {
@@ -129,14 +125,6 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
     setUserWithReviewsFilter((filter) => ({
       ...filter,
       status: getFilterStatus(reviewStatus),
-    }));
-  };
-
-  const handleReviewOwnerFilterChange = (reviewer: ReviewerFilter) => {
-    setUrlQueryParams((queries) => ({ ...queries, reviewer }));
-    setUserWithReviewsFilter((filter) => ({
-      ...filter,
-      reviewer,
     }));
   };
 
@@ -346,10 +334,6 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
 
   return (
     <>
-      <ReviewerFilterComponent
-        reviewer={urlQueryParams.reviewer}
-        onChange={handleReviewOwnerFilterChange}
-      />
       <ReviewStatusFilter
         reviewStatus={urlQueryParams.reviewStatus}
         onChange={handleStatusFilterChange}

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -2214,7 +2214,6 @@ export type QueryQuestionsArgs = {
 
 export type QueryReviewArgs = {
   reviewId: Scalars['Int'];
-  sepId?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -3975,7 +3974,6 @@ export type GetProposalReviewsQuery = { proposalReviews: Array<{ id: number, use
 
 export type GetReviewQueryVariables = Exact<{
   reviewId: Scalars['Int'];
-  sepId?: InputMaybe<Scalars['Int']>;
 }>;
 
 
@@ -7157,8 +7155,8 @@ export const GetProposalReviewsDocument = gql`
 }
     `;
 export const GetReviewDocument = gql`
-    query getReview($reviewId: Int!, $sepId: Int) {
-  review(reviewId: $reviewId, sepId: $sepId) {
+    query getReview($reviewId: Int!) {
+  review(reviewId: $reviewId) {
     ...coreReview
     proposal {
       primaryKey

--- a/src/graphql/review/getReview.graphql
+++ b/src/graphql/review/getReview.graphql
@@ -1,5 +1,5 @@
-query getReview($reviewId: Int!, $sepId: Int) {
-  review(reviewId: $reviewId, sepId: $sepId) {
+query getReview($reviewId: Int!) {
+  review(reviewId: $reviewId) {
     ...coreReview
     proposal {
       primaryKey

--- a/src/hooks/review/useReviewData.ts
+++ b/src/hooks/review/useReviewData.ts
@@ -15,7 +15,7 @@ export function useReviewData(reviewId?: number | null, sepId?: number | null) {
     if (reviewId) {
       setLoading(true);
       api()
-        .getReview({ reviewId, sepId })
+        .getReview({ reviewId })
         .then((data) => {
           if (cancelled) {
             return;


### PR DESCRIPTION
## Description
This PR removes dropdown for reviewer, because reviewer should only see his/her proposals
![image](https://user-images.githubusercontent.com/58165815/161562379-4ca69289-580e-4768-8cd8-442bd43c2de1.png)



## Motivation and Context

According to our business logic, reviewer should not be able to see/interact with proposals he/she is not assigned to

## How Has This Been Tested
- [x] E2E
- [x] Manual tests


## Fixes

https://jira.esss.lu.se/browse/SWAP-2480

## Changes
- ProposalTableReviewer.tsx

## Depends on

https://github.com/UserOfficeProject/user-office-backend/pull/618


## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
