### PR TITLE
fix: Reorder information in the modal for SEP meeting components where the more important details come first

### DIFF
--- a/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
@@ -138,7 +138,9 @@ const SEPMeetingProposalViewModal: React.FC<
                         meetingSubmitted(data);
                       }}
                     />
-                    <ProposalDetails proposal={proposalData} />
+                    <ExternalReviews
+                      reviews={proposalData.reviews as Review[]}
+                    />
                     <TechnicalReviewInfo
                       hasWriteAccess={finalHasWriteAccess}
                       technicalReview={
@@ -154,9 +156,7 @@ const SEPMeetingProposalViewModal: React.FC<
                       proposal={proposalData}
                       sepId={sepId}
                     />
-                    <ExternalReviews
-                      reviews={proposalData.reviews as Review[]}
-                    />
+                    <ProposalDetails proposal={proposalData} />
                   </>
                 )}
               </div>


### PR DESCRIPTION
## Description

Reorder of the information in SEP meeting components modal according to importance.
- Show form first
- Then show reviews
- and proposal information comes in the end