### PR TITLE
feat: Improve UX for reordering of the meeting component proposals. No spinner is shown anymore

### DIFF
--- a/cypress/integration/SEP.ts
+++ b/cypress/integration/SEP.ts
@@ -884,7 +884,10 @@ context('SEP meeting components tests', () => {
       cy.get('@secondDragIcon').trigger('dragenter');
 
       cy.get('@secondDragIcon').trigger('dragend');
-      cy.finishedLoading();
+
+      cy.get(
+        '[data-cy="sep-instrument-proposals-table"] [role="progressbar"]'
+      ).should('not.exist');
 
       cy.notification({
         variant: 'success',

--- a/src/components/AppToolbar/RoleSelection.tsx
+++ b/src/components/AppToolbar/RoleSelection.tsx
@@ -57,7 +57,9 @@ const RoleSelection: React.FC<{ onClose: FunctionType }> = ({ onClose }) => {
 
   const selectUserRole = async (role: Role) => {
     setLoading(true);
-    const result = await api('User role changed!').selectRole({
+    const result = await api({
+      toastSuccessMessage: 'User role changed!',
+    }).selectRole({
       token,
       selectedRoleId: role.id,
     });

--- a/src/components/SEP/General/AddSEP.tsx
+++ b/src/components/SEP/General/AddSEP.tsx
@@ -35,7 +35,9 @@ const AddSEP: React.FC<AddSEPProps> = ({ close }) => {
         active: true,
       }}
       onSubmit={async (values): Promise<void> => {
-        const data = await api('SEP created successfully!').createSEP(values);
+        const data = await api({
+          toastSuccessMessage: 'SEP created successfully!',
+        }).createSEP(values);
 
         if (data.createSEP.rejection) {
           close(null);

--- a/src/components/SEP/General/SEPGeneralInfo.tsx
+++ b/src/components/SEP/General/SEPGeneralInfo.tsx
@@ -36,7 +36,9 @@ const SEPGeneralInfo: React.FC<SEPPageProps> = ({ data, onSEPUpdate }) => {
   const hasAccessRights = useCheckAccess([UserRole.USER_OFFICER]);
 
   const sendSEPUpdate = async (values: Sep): Promise<void> => {
-    await api('SEP updated successfully!').updateSEP(values);
+    await api({ toastSuccessMessage: 'SEP updated successfully!' }).updateSEP(
+      values
+    );
     onSEPUpdate(values);
   };
 

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/FinalRankingForm.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/FinalRankingForm.tsx
@@ -88,11 +88,11 @@ const FinalRankingForm: React.FC<FinalRankingFormProps> = ({
       submitted: shouldSubmitMeetingDecision,
     };
 
-    const data = await api(
-      `SEP meeting decision ${
+    const data = await api({
+      toastSuccessMessage: `SEP meeting decision ${
         shouldSubmitMeetingDecision ? 'submitted' : 'saved'
-      } successfully!`
-    ).saveSepMeetingDecision({ saveSepMeetingDecisionInput });
+      } successfully!`,
+    }).saveSepMeetingDecision({ saveSepMeetingDecisionInput });
 
     const isError = !!data.saveSepMeetingDecision.rejection;
 

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/TechnicalReviewInfo.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/TechnicalReviewInfo.tsx
@@ -92,7 +92,9 @@ const OverwriteTimeAllocationDialog = ({
       <Formik
         initialValues={initialValues}
         onSubmit={async (values) => {
-          const result = await api('Updated').updateSEPTimeAllocation(values);
+          const result = await api({
+            toastSuccessMessage: 'Updated',
+          }).updateSEPTimeAllocation(values);
 
           if (result.updateSEPTimeAllocation.rejection) {
             return;

--- a/src/components/SEP/MeetingComponents/SEPMeetingInstrumentsTable.tsx
+++ b/src/components/SEP/MeetingComponents/SEPMeetingInstrumentsTable.tsx
@@ -91,9 +91,9 @@ const SEPMeetingInstrumentsTable: React.FC<SEPMeetingInstrumentsTableProps> = ({
         );
 
       if (allProposalsOnInstrumentHaveRankings) {
-        const { submitInstrument } = await api(
-          'Instrument submitted!'
-        ).submitInstrument({
+        const { submitInstrument } = await api({
+          toastSuccessMessage: 'Instrument submitted!',
+        }).submitInstrument({
           callId: selectedCall.id,
           instrumentId: instrumentToSubmit.id,
           sepId: sepId,

--- a/src/components/SEP/Members/SEPMembers.tsx
+++ b/src/components/SEP/Members/SEPMembers.tsx
@@ -91,7 +91,9 @@ const SEPMembers: React.FC<SEPMembersProps> = ({
 
     const {
       assignChairOrSecretary: { rejection },
-    } = await api('SEP chair assigned successfully!').assignChairOrSecretary({
+    } = await api({
+      toastSuccessMessage: 'SEP chair assigned successfully!',
+    }).assignChairOrSecretary({
       assignChairOrSecretaryToSEPInput: {
         sepId: sepId,
         roleId: UserRole.SEP_CHAIR,
@@ -122,9 +124,9 @@ const SEPMembers: React.FC<SEPMembersProps> = ({
 
     const {
       assignChairOrSecretary: { rejection },
-    } = await api(
-      'SEP secretary assigned successfully!'
-    ).assignChairOrSecretary({
+    } = await api({
+      toastSuccessMessage: 'SEP secretary assigned successfully!',
+    }).assignChairOrSecretary({
       assignChairOrSecretaryToSEPInput: {
         sepId: sepId,
         roleId: UserRole.SEP_SECRETARY,
@@ -152,7 +154,9 @@ const SEPMembers: React.FC<SEPMembersProps> = ({
   const addMember = async (users: BasicUserDetails[]): Promise<void> => {
     const {
       assignReviewersToSEP: { rejection },
-    } = await api('SEP member assigned successfully!').assignReviewersToSEP({
+    } = await api({
+      toastSuccessMessage: 'SEP member assigned successfully!',
+    }).assignReviewersToSEP({
       memberIds: users.map((user) => user.id),
       sepId,
     });
@@ -174,7 +178,9 @@ const SEPMembers: React.FC<SEPMembersProps> = ({
   ): Promise<void> => {
     const {
       removeMemberFromSep: { rejection },
-    } = await api('SEP member removed successfully!').removeMemberFromSep({
+    } = await api({
+      toastSuccessMessage: 'SEP member removed successfully!',
+    }).removeMemberFromSep({
       memberId: user.id,
       sepId,
       roleId: user.roleId,

--- a/src/components/SEP/Proposals/SEPProposalsAndAssignmentsTable.tsx
+++ b/src/components/SEP/Proposals/SEPProposalsAndAssignmentsTable.tsx
@@ -199,7 +199,9 @@ const SEPProposalsAndAssignmentsTable: React.FC<
   const removeProposalsFromSEP = async (
     proposalsToRemove: SEPProposalType[]
   ): Promise<void> => {
-    await api('Assignment/s removed').removeProposalsFromSep({
+    await api({
+      toastSuccessMessage: 'Assignment/s removed',
+    }).removeProposalsFromSep({
       proposalPks: proposalsToRemove.map(
         (proposalToRemove) => proposalToRemove.proposalPk
       ),
@@ -240,7 +242,9 @@ const SEPProposalsAndAssignmentsTable: React.FC<
 
     const {
       assignSepReviewersToProposal: { rejection },
-    } = await api('Members assigned').assignSepReviewersToProposal({
+    } = await api({
+      toastSuccessMessage: 'Members assigned',
+    }).assignSepReviewersToProposal({
       memberIds: assignedMembers.map(({ id }) => id),
       proposalPk: proposalPk,
       sepId,
@@ -359,7 +363,9 @@ const SEPProposalsAndAssignmentsTable: React.FC<
          * TODO(asztalos): merge `removeMemberFromSEPProposal` and `removeUserForReview` (same goes for creation)
          *                otherwise if one of them fails we may end up with an broken state
          */
-        await api('Reviewer removed').removeMemberFromSEPProposal({
+        await api({
+          toastSuccessMessage: 'Reviewer removed',
+        }).removeMemberFromSEPProposal({
           proposalPk,
           sepId,
           memberId: assignedReviewer.sepMemberUserId as number,

--- a/src/components/SEP/SEPsTable.tsx
+++ b/src/components/SEP/SEPsTable.tsx
@@ -69,7 +69,7 @@ const SEPsTable: React.FC = () => {
   const EditIcon = (): JSX.Element => <Edit />;
 
   const deleteSEP = async (id: number | string) => {
-    return await api('SEP deleted successfully')
+    return await api({ toastSuccessMessage: 'SEP deleted successfully' })
       .deleteSEP({
         id: id as number,
       })

--- a/src/components/call/AssignInstrumentsToCall.tsx
+++ b/src/components/call/AssignInstrumentsToCall.tsx
@@ -48,9 +48,9 @@ const AssignInstrumentsToCall: React.FC<AssignInstrumentsToCallProps> = ({
   }) as Instrument[];
 
   const onAssignButtonClick = async () => {
-    const assignInstrumentToCallResult = await api(
-      'Instrument/s assigned successfully!'
-    ).assignInstrumentsToCall({
+    const assignInstrumentToCallResult = await api({
+      toastSuccessMessage: 'Instrument/s assigned successfully!',
+    }).assignInstrumentsToCall({
       callId,
       instrumentIds: selectedInstruments.map(
         (instrumentToAssign) => instrumentToAssign.id

--- a/src/components/call/AssignedInstrumentsTable.tsx
+++ b/src/components/call/AssignedInstrumentsTable.tsx
@@ -89,9 +89,9 @@ const AssignedInstrumentsTable: React.FC<AssignedInstrumentsTableProps> = ({
   ];
 
   const removeAssignedInstrument = async (instrumentId: number) => {
-    const result = await api(
-      'Assigned instrument removed successfully!'
-    ).removeAssignedInstrumentFromCall({
+    const result = await api({
+      toastSuccessMessage: 'Assigned instrument removed successfully!',
+    }).removeAssignedInstrumentFromCall({
       callId: call.id,
       instrumentId,
     });
@@ -108,9 +108,9 @@ const AssignedInstrumentsTable: React.FC<AssignedInstrumentsTableProps> = ({
     id: number;
     availabilityTime: number | string;
   }) => {
-    const result = await api(
-      'Availability time set successfully!'
-    ).setInstrumentAvailabilityTime({
+    const result = await api({
+      toastSuccessMessage: 'Availability time set successfully!',
+    }).setInstrumentAvailabilityTime({
       callId: call.id,
       instrumentId: instrumentUpdatedData.id,
       availabilityTime: +instrumentUpdatedData.availabilityTime,

--- a/src/components/call/CallsTable.tsx
+++ b/src/components/call/CallsTable.tsx
@@ -121,7 +121,7 @@ const CallsTable: React.FC = () => {
   };
 
   const deleteCall = async (id: number | string) => {
-    return await api('Call deleted successfully')
+    return await api({ toastSuccessMessage: 'Call deleted successfully' })
       .deleteCall({
         id: id as number,
       })

--- a/src/components/call/CreateUpdateCall.tsx
+++ b/src/components/call/CreateUpdateCall.tsx
@@ -120,17 +120,17 @@ const CreateUpdateCall: React.FC<CreateUpdateCallProps> = ({ call, close }) => {
         initialValues={initialValues}
         onSubmit={async (values) => {
           if (call) {
-            const data = await api('Call updated successfully!').updateCall(
-              values as UpdateCallInput
-            );
+            const data = await api({
+              toastSuccessMessage: 'Call updated successfully!',
+            }).updateCall(values as UpdateCallInput);
             closeModal(
               data.updateCall.rejection?.reason,
               data.updateCall.call as Call
             );
           } else {
-            const data = await api('Call created successfully!').createCall(
-              values as UpdateCallInput
-            );
+            const data = await api({
+              toastSuccessMessage: 'Call created successfully!',
+            }).createCall(values as UpdateCallInput);
 
             closeModal(
               data.createCall.rejection?.reason,

--- a/src/components/institution/CreateUpdateInstitution.tsx
+++ b/src/components/institution/CreateUpdateInstitution.tsx
@@ -60,9 +60,9 @@ const CreateUpdateInstitution: React.FC<CreateUpdateInstitutionProps> = ({
     name: string,
     country: number
   ) => {
-    const response = await api(
-      'Institution created successfully!'
-    ).createInstitution({
+    const response = await api({
+      toastSuccessMessage: 'Institution created successfully!',
+    }).createInstitution({
       name,
       country,
       verified,
@@ -82,9 +82,9 @@ const CreateUpdateInstitution: React.FC<CreateUpdateInstitutionProps> = ({
     country: number,
     name: string
   ) => {
-    const response = await api(
-      'Institution updated successfully!'
-    ).updateInstitution({
+    const response = await api({
+      toastSuccessMessage: 'Institution updated successfully!',
+    }).updateInstitution({
       id,
       name,
       verified,

--- a/src/components/institution/InstitutionTable.tsx
+++ b/src/components/institution/InstitutionTable.tsx
@@ -28,7 +28,9 @@ const InstitutionPage: React.FC = () => {
     useQueryParams<UrlQueryParamsType>(DefaultQueryParams);
 
   const deleteInstitution = async (id: number | string) => {
-    return await api('Institution removed successfully!')
+    return await api({
+      toastSuccessMessage: 'Institution removed successfully!',
+    })
       .deleteInstitution({
         id: id as number,
       })

--- a/src/components/institution/MergeInstitutionPage.tsx
+++ b/src/components/institution/MergeInstitutionPage.tsx
@@ -136,7 +136,7 @@ function MergeInstitutionsPage({ confirm }: MergeInstitutionPageProps) {
                   }
                   confirm(
                     () => {
-                      api('Institutions merged')
+                      api({ toastSuccessMessage: 'Institutions merged' })
                         .mergeInstitutions({
                           institutionIdFrom: institutionFrom.id,
                           institutionIdInto: institutionInto.id,

--- a/src/components/instrument/AssignedScientistsTable.tsx
+++ b/src/components/instrument/AssignedScientistsTable.tsx
@@ -53,9 +53,9 @@ const AssignedScientistsTable: React.FC<AssignedScientistsTableProps> = ({
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
 
   const removeAssignedScientist = async (scientistId: number) => {
-    const result = await api(
-      'Scientist removed from instrument!'
-    ).removeScientistFromInstrument({
+    const result = await api({
+      toastSuccessMessage: 'Scientist removed from instrument!',
+    }).removeScientistFromInstrument({
       scientistId,
       instrumentId: instrument.id,
     });

--- a/src/components/instrument/CreateUpdateInstrument.tsx
+++ b/src/components/instrument/CreateUpdateInstrument.tsx
@@ -59,9 +59,9 @@ const CreateUpdateInstrument: React.FC<CreateUpdateInstrumentProps> = ({
         }
 
         if (instrument) {
-          const data = await api(
-            'Instrument updated successfully!'
-          ).updateInstrument({
+          const data = await api({
+            toastSuccessMessage: 'Instrument updated successfully!',
+          }).updateInstrument({
             ...values,
             id: instrument.id,
           });
@@ -71,9 +71,9 @@ const CreateUpdateInstrument: React.FC<CreateUpdateInstrumentProps> = ({
             close(data.updateInstrument.instrument);
           }
         } else {
-          const data = await api(
-            'Instrument created successfully!'
-          ).createInstrument(values);
+          const data = await api({
+            toastSuccessMessage: 'Instrument created successfully!',
+          }).createInstrument(values);
           if (data.createInstrument.rejection) {
             close(null);
           } else if (data.createInstrument.instrument) {

--- a/src/components/instrument/InstrumentTable.tsx
+++ b/src/components/instrument/InstrumentTable.tsx
@@ -48,7 +48,9 @@ const InstrumentTable: React.FC = () => {
     useQueryParams<UrlQueryParamsType>(DefaultQueryParams);
 
   const onInstrumentDelete = async (instrumentDeletedId: number | string) => {
-    return await api('Instrument removed successfully!')
+    return await api({
+      toastSuccessMessage: 'Instrument removed successfully!',
+    })
       .deleteInstrument({
         id: instrumentDeletedId as number,
       })
@@ -64,9 +66,9 @@ const InstrumentTable: React.FC = () => {
   const assignScientistsToInstrument = async (
     scientists: BasicUserDetails[]
   ) => {
-    const assignScientistToInstrumentResult = await api(
-      'Scientist assigned to instrument successfully!'
-    ).assignScientistsToInstrument({
+    const assignScientistToInstrumentResult = await api({
+      toastSuccessMessage: 'Scientist assigned to instrument successfully!',
+    }).assignScientistsToInstrument({
       instrumentId: assigningInstrumentId as number,
       scientistIds: scientists.map((scientist) => scientist.id),
     });

--- a/src/components/pages/PageInputBox.tsx
+++ b/src/components/pages/PageInputBox.tsx
@@ -72,7 +72,7 @@ export default function PageInputBox(props: {
         <Button
           className={classes.button}
           onClick={() =>
-            api('Updated Page').setPageContent({
+            api({ toastSuccessMessage: 'Updated Page' }).setPageContent({
               id: props.pageName,
               text: content,
             })

--- a/src/components/proposal/ProposalAdmin.tsx
+++ b/src/components/proposal/ProposalAdmin.tsx
@@ -70,9 +70,9 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
   const handleProposalAdministration = async (
     administrationValues: AdministrationFormData
   ) => {
-    const result = await api('Saved!').administrationProposal(
-      administrationValues
-    );
+    const result = await api({
+      toastSuccessMessage: 'Saved!',
+    }).administrationProposal(administrationValues);
 
     if (!result.administrationProposal.rejection) {
       setAdministration(administrationValues);

--- a/src/components/proposal/ProposalTable.tsx
+++ b/src/components/proposal/ProposalTable.tsx
@@ -110,7 +110,9 @@ const ProposalTable = ({
       return;
     }
 
-    const result = await api('Proposal cloned successfully').cloneProposals({
+    const result = await api({
+      toastSuccessMessage: 'Proposal cloned successfully',
+    }).cloneProposals({
       callId: call.id,
       proposalsToClonePk: [proposalToClone.primaryKey],
     });

--- a/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -271,9 +271,9 @@ const ProposalTableInstrumentScientist: React.FC<{
           submitted: true,
         }));
 
-      const result = await api(
-        `Proposal${shouldAddPluralLetter} technical review submitted successfully!`
-      ).submitTechnicalReviews({
+      const result = await api({
+        toastSuccessMessage: `Proposal${shouldAddPluralLetter} technical review submitted successfully!`,
+      }).submitTechnicalReviews({
         technicalReviews: submittedTechnicalReviewsInput,
       });
 

--- a/src/components/proposal/ProposalTableOfficer.tsx
+++ b/src/components/proposal/ProposalTableOfficer.tsx
@@ -325,7 +325,9 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
     selectedProposals.forEach(async (proposal) => {
       const {
         notifyProposal: { rejection },
-      } = await api('Notification sent successfully').notifyProposal({
+      } = await api({
+        toastSuccessMessage: 'Notification sent successfully',
+      }).notifyProposal({
         proposalPk: proposal.primaryKey,
       });
 
@@ -362,9 +364,10 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
 
   const assignProposalsToSEP = async (sep: Sep | null): Promise<void> => {
     if (sep) {
-      const response = await api(
-        'Proposal/s assigned to the selected SEP successfully!'
-      ).assignProposalsToSep({
+      const response = await api({
+        toastSuccessMessage:
+          'Proposal/s assigned to the selected SEP successfully!',
+      }).assignProposalsToSep({
         proposals: selectedProposals.map((selectedProposal) => ({
           primaryKey: selectedProposal.primaryKey,
           callId: selectedProposal.callId,
@@ -397,9 +400,9 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         );
       }
     } else {
-      const result = await api(
-        'Proposal/s removed from the SEP successfully!'
-      ).removeProposalsFromSep({
+      const result = await api({
+        toastSuccessMessage: 'Proposal/s removed from the SEP successfully!',
+      }).removeProposalsFromSep({
         proposalPks: selectedProposals.map(
           (selectedProposal) => selectedProposal.primaryKey
         ),
@@ -432,9 +435,10 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
     instrument: InstrumentFragment | null
   ): Promise<void> => {
     if (instrument) {
-      const result = await api(
-        'Proposal/s assigned to the selected instrument successfully!'
-      ).assignProposalsToInstrument({
+      const result = await api({
+        toastSuccessMessage:
+          'Proposal/s assigned to the selected instrument successfully!',
+      }).assignProposalsToInstrument({
         proposals: selectedProposals.map((selectedProposal) => ({
           primaryKey: selectedProposal.primaryKey,
           callId: selectedProposal.callId,
@@ -461,9 +465,10 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
         );
       }
     } else {
-      const result = await api(
-        'Proposal/s removed from the instrument successfully!'
-      ).removeProposalsFromInstrument({
+      const result = await api({
+        toastSuccessMessage:
+          'Proposal/s removed from the instrument successfully!',
+      }).removeProposalsFromInstrument({
         proposalPks: selectedProposals.map(
           (selectedProposal) => selectedProposal.primaryKey
         ),
@@ -500,7 +505,9 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
       (selectedProposal) => selectedProposal.primaryKey
     );
 
-    const result = await api('Proposal/s cloned successfully').cloneProposals({
+    const result = await api({
+      toastSuccessMessage: 'Proposal/s cloned successfully',
+    }).cloneProposals({
       callId: call.id,
       proposalsToClonePk,
     });
@@ -520,9 +527,9 @@ const ProposalTableOfficer: React.FC<ProposalTableOfficerProps> = ({
   const changeStatusOnProposals = async (status: ProposalStatus) => {
     if (status?.id && selectedProposals?.length) {
       const shouldAddPluralLetter = selectedProposals.length > 1 ? 's' : '';
-      const result = await api(
-        `Proposal${shouldAddPluralLetter} status changed successfully!`
-      ).changeProposalsStatus({
+      const result = await api({
+        toastSuccessMessage: `Proposal${shouldAddPluralLetter} status changed successfully!`,
+      }).changeProposalsStatus({
         proposals: selectedProposals.map((selectedProposal) => ({
           primaryKey: selectedProposal.primaryKey,
           callId: selectedProposal.callId,

--- a/src/components/proposalBooking/CreateUpdateVisit.tsx
+++ b/src/components/proposalBooking/CreateUpdateVisit.tsx
@@ -49,7 +49,7 @@ function CreateUpdateVisit({ event, close }: CreateUpdateVisitProps) {
       })}
       onSubmit={async (values): Promise<void> => {
         if (visit) {
-          api('Visit updated')
+          api({ toastSuccessMessage: 'Visit updated' })
             .updateVisit({
               visitId: visit.id,
               team: values.team.map((user) => user.id),
@@ -61,7 +61,7 @@ function CreateUpdateVisit({ event, close }: CreateUpdateVisitProps) {
               }
             });
         } else {
-          api('Visit created')
+          api({ toastSuccessMessage: 'Visit created' })
             .createVisit({
               scheduledEventId: event.id,
               team: values.team?.map((user) => user.id),

--- a/src/components/questionary/QuestionaryStepView.tsx
+++ b/src/components/questionary/QuestionaryStepView.tsx
@@ -167,7 +167,9 @@ export default function QuestionaryStepView(props: {
       return false;
     }
 
-    const answerTopicResult = await api('Saved').answerTopic({
+    const answerTopicResult = await api({
+      toastSuccessMessage: 'Saved',
+    }).answerTopic({
       questionaryId: questionaryId,
       answers: prepareAnswers(activeFields),
       topicId: topicId,

--- a/src/components/review/AssignTechnicalReview.tsx
+++ b/src/components/review/AssignTechnicalReview.tsx
@@ -69,9 +69,11 @@ function AssignTechnicalReview({
             if (selectedUser) {
               confirm(
                 () =>
-                  api(
-                    `Assigned to ${getFullUserName(userIdToUser(selectedUser))}`
-                  )
+                  api({
+                    toastSuccessMessage: `Assigned to ${getFullUserName(
+                      userIdToUser(selectedUser)
+                    )}`,
+                  })
                     .updateTechnicalReviewAssignee({
                       userId: selectedUser,
                       proposalPks: [proposal.primaryKey],

--- a/src/components/review/ProposalGrade.tsx
+++ b/src/components/review/ProposalGrade.tsx
@@ -88,7 +88,9 @@ const ProposalGrade: React.FC<ProposalGradeProps> = ({
   const handleSubmit = async (values: GradeFormType) => {
     const {
       updateReview: { rejection, review: updatedReview },
-    } = await api(shouldSubmit ? 'Submitted' : 'Updated').updateReview({
+    } = await api({
+      toastSuccessMessage: shouldSubmit ? 'Submitted' : 'Updated',
+    }).updateReview({
       reviewID: review.id,
       grade: +values.grade,
       comment: values.comment ? values.comment : '',

--- a/src/components/review/ProposalTableReviewer.tsx
+++ b/src/components/review/ProposalTableReviewer.tsx
@@ -291,9 +291,9 @@ const ProposalTableReviewer: React.FC<{ confirm: WithConfirmType }> = ({
         reviewId: proposal.reviewId,
       }));
 
-      const result = await api(
-        `Proposal${shouldAddPluralLetter} review submitted successfully!`
-      ).submitProposalsReview({ proposals: submitProposalReviewsInput });
+      const result = await api({
+        toastSuccessMessage: `Proposal${shouldAddPluralLetter} review submitted successfully!`,
+      }).submitProposalsReview({ proposals: submitProposalReviewsInput });
 
       const isError = !!result.submitProposalsReview.rejection;
 

--- a/src/components/review/ProposalTechnicalReview.tsx
+++ b/src/components/review/ProposalTechnicalReview.tsx
@@ -111,7 +111,7 @@ const ProposalTechnicalReview = ({
     const shouldSubmit =
       method === 'submitTechnicalReviews' ||
       (isUserOfficer && values.submitted);
-    const successMessage = isUserOfficer
+    const toastSuccessMessage = isUserOfficer
       ? `Technical review updated successfully!`
       : `Technical review ${
           shouldSubmit ? 'submitted' : 'updated'
@@ -120,7 +120,7 @@ const ProposalTechnicalReview = ({
     let result;
 
     if (method === 'submitTechnicalReviews') {
-      result = await api(successMessage)[method]({
+      result = await api({ toastSuccessMessage })[method]({
         technicalReviews: [
           {
             proposalPk: proposal.primaryKey,
@@ -136,7 +136,7 @@ const ProposalTechnicalReview = ({
         ],
       });
     } else {
-      result = await api(successMessage)[method]({
+      result = await api({ toastSuccessMessage })[method]({
         proposalPk: proposal.primaryKey,
         timeAllocation: +values.timeAllocation,
         comment: values.comment,

--- a/src/components/sample/SampleSafetyPage.tsx
+++ b/src/components/sample/SampleSafetyPage.tsx
@@ -51,9 +51,9 @@ function SampleEvaluationDialog(props: {
           }
 
           const { id, safetyComment, safetyStatus } = values;
-          const result = await api(
-            `Review for '${sample?.title}' submitted`
-          ).updateSample({ sampleId: id, safetyComment, safetyStatus });
+          const result = await api({
+            toastSuccessMessage: `Review for '${sample?.title}' submitted`,
+          }).updateSample({ sampleId: id, safetyComment, safetyStatus });
 
           const updatedSample = result.updateSample.sample;
           onClose({ ...values, ...updatedSample } || null);

--- a/src/components/settings/apiAccessTokens/ApiAccessTokensTable.tsx
+++ b/src/components/settings/apiAccessTokens/ApiAccessTokensTable.tsx
@@ -47,7 +47,9 @@ const ApiAccessTokensTable: React.FC = () => {
   );
 
   const deleteApiAccessToken = async (id: string | number) => {
-    return await api('Api access token deleted successfully')
+    return await api({
+      toastSuccessMessage: 'Api access token deleted successfully',
+    })
       .deleteApiAccessToken({
         accessTokenId: id as string,
       })

--- a/src/components/settings/apiAccessTokens/CreateUpdateApiAccessToken.tsx
+++ b/src/components/settings/apiAccessTokens/CreateUpdateApiAccessToken.tsx
@@ -167,9 +167,9 @@ const CreateUpdateApiAccessToken: React.FC<CreateUpdateApiAccessTokenProps> = ({
         });
 
         if (apiAccessToken) {
-          const data = await api(
-            'Api access token updated successfully!'
-          ).updateApiAccessToken({
+          const data = await api({
+            toastSuccessMessage: 'Api access token updated successfully!',
+          }).updateApiAccessToken({
             accessTokenId: apiAccessToken.id,
             name: values.name,
             accessPermissions: JSON.stringify(accessPermissions),
@@ -180,9 +180,9 @@ const CreateUpdateApiAccessToken: React.FC<CreateUpdateApiAccessTokenProps> = ({
             close(data.updateApiAccessToken.apiAccessToken);
           }
         } else {
-          const data = await api(
-            'Api access token created successfully!'
-          ).createApiAccessToken({
+          const data = await api({
+            toastSuccessMessage: 'Api access token created successfully!',
+          }).createApiAccessToken({
             ...values,
             accessPermissions: JSON.stringify(accessPermissions),
           });

--- a/src/components/settings/proposalStatus/CreateUpdateProposalStatus.tsx
+++ b/src/components/settings/proposalStatus/CreateUpdateProposalStatus.tsx
@@ -50,9 +50,9 @@ const CreateUpdateProposalStatus: React.FC<CreateUpdateProposalStatusProps> = ({
       initialValues={initialValues}
       onSubmit={async (values): Promise<void> => {
         if (proposalStatus) {
-          const data = await api(
-            'Proposal status updated successfully'
-          ).updateProposalStatus({
+          const data = await api({
+            toastSuccessMessage: 'Proposal status updated successfully',
+          }).updateProposalStatus({
             id: proposalStatus.id,
             ...values,
           });
@@ -62,9 +62,9 @@ const CreateUpdateProposalStatus: React.FC<CreateUpdateProposalStatusProps> = ({
             close(data.updateProposalStatus.proposalStatus);
           }
         } else {
-          const data = await api(
-            'Proposal status created successfully'
-          ).createProposalStatus(values);
+          const data = await api({
+            toastSuccessMessage: 'Proposal status created successfully',
+          }).createProposalStatus(values);
           if (data.createProposalStatus.rejection) {
             close(null);
           } else if (data.createProposalStatus.proposalStatus) {

--- a/src/components/settings/proposalStatus/ProposalStatusesTable.tsx
+++ b/src/components/settings/proposalStatus/ProposalStatusesTable.tsx
@@ -52,7 +52,9 @@ const ProposalStatusesTable: React.FC<{ confirm: WithConfirmType }> = ({
   );
 
   const deleteProposalStatus = async (id: number) => {
-    return await api('Proposal status deleted successfully')
+    return await api({
+      toastSuccessMessage: 'Proposal status deleted successfully',
+    })
       .deleteProposalStatus({
         id: id,
       })

--- a/src/components/settings/proposalWorkflow/CreateProposalWorkflow.tsx
+++ b/src/components/settings/proposalWorkflow/CreateProposalWorkflow.tsx
@@ -37,9 +37,9 @@ const CreateProposalWorkflow: React.FC<CreateProposalWorkflowProps> = ({
     <Formik
       initialValues={initialValues}
       onSubmit={async (values): Promise<void> => {
-        const data = await api(
-          'Proposal workflow created successfully'
-        ).createProposalWorkflow(values);
+        const data = await api({
+          toastSuccessMessage: 'Proposal workflow created successfully',
+        }).createProposalWorkflow(values);
         if (data.createProposalWorkflow.rejection) {
           close(null);
         } else if (data.createProposalWorkflow.proposalWorkflow) {

--- a/src/components/settings/proposalWorkflow/ProposalWorkflowsTable.tsx
+++ b/src/components/settings/proposalWorkflow/ProposalWorkflowsTable.tsx
@@ -50,7 +50,9 @@ const ProposalWorkflowsTable: React.FC = () => {
   );
 
   const deleteProposalWorkflow = async (id: number | string) => {
-    return await api('Proposal workflow deleted successfully')
+    return await api({
+      toastSuccessMessage: 'Proposal workflow deleted successfully',
+    })
       .deleteProposalWorkflow({
         id: id as number,
       })

--- a/src/components/settings/unitList/CreateUnit.tsx
+++ b/src/components/settings/unitList/CreateUnit.tsx
@@ -45,7 +45,9 @@ const CreateUnit: React.FC<CreateUnitProps> = ({ close, unit }) => {
     <Formik
       initialValues={initialValues}
       onSubmit={async (newUnit): Promise<void> => {
-        const data = await api('Unit created successfully').createUnit(newUnit);
+        const data = await api({
+          toastSuccessMessage: 'Unit created successfully',
+        }).createUnit(newUnit);
         if (data.createUnit.unit) {
           close(data.createUnit.unit);
         }

--- a/src/components/settings/unitList/UnitTable.tsx
+++ b/src/components/settings/unitList/UnitTable.tsx
@@ -47,7 +47,7 @@ const UnitTable: React.FC = () => {
   );
 
   const deleteUnit = async (id: string | number) => {
-    return await api('Unit deleted successfully')
+    return await api({ toastSuccessMessage: 'Unit deleted successfully' })
       .deleteUnit({ id: id as string })
       .then((resp) => resp.deleteUnit.rejection === null);
   };

--- a/src/components/template/QuestionsPage.tsx
+++ b/src/components/template/QuestionsPage.tsx
@@ -66,7 +66,7 @@ function QuestionsPage() {
   };
 
   const deleteQuestion = async (questionId: string | number) =>
-    api('Question deleted')
+    api({ toastSuccessMessage: 'Question deleted' })
       .deleteQuestion({ questionId: questionId as string })
       .then((result) => result.deleteQuestion.rejection === null);
 

--- a/src/components/template/TemplatesTable.tsx
+++ b/src/components/template/TemplatesTable.tsx
@@ -113,7 +113,7 @@ const TemplatesTable = ({
       ) => {
         confirm(
           () => {
-            api('Template archived successfully')
+            api({ toastSuccessMessage: 'Template archived successfully' })
               .updateTemplate({
                 templateId: (data as TemplateRowDataType).templateId,
                 isArchived: true,

--- a/src/components/template/import/MergeReview.tsx
+++ b/src/components/template/import/MergeReview.tsx
@@ -61,7 +61,7 @@ export function MergeReview(props: MergeReviewProps) {
   );
 
   const handleImportClick = () =>
-    api('Template imported successfully')
+    api({ toastSuccessMessage: 'Template imported successfully' })
       .importTemplate({
         templateAsJson: json,
         conflictResolutions: state.questionComparisons.map((comparison) => {

--- a/src/components/user/InviteUserForm.tsx
+++ b/src/components/user/InviteUserForm.tsx
@@ -46,9 +46,9 @@ const InviteUserForm: React.FC<InviteUserFormProps> = ({
         userRole: userRole,
       }}
       onSubmit={async (values): Promise<void> => {
-        const createResult = await api(
-          'Invitation sent successfully!'
-        ).createUserByEmailInvite({
+        const createResult = await api({
+          toastSuccessMessage: 'Invitation sent successfully!',
+        }).createUserByEmailInvite({
           firstname: values.firstname,
           lastname: values.lastname,
           email: values.email,

--- a/src/components/user/PeoplePage.tsx
+++ b/src/components/user/PeoplePage.tsx
@@ -32,7 +32,9 @@ export default function PeoplePage() {
           selection={false}
           showInvitationButtons
           onRemove={(user: { id: number }) =>
-            api('User removed successfully!').deleteUser({
+            api({
+              toastSuccessMessage: 'User removed successfully!',
+            }).deleteUser({
               id: user.id,
             })
           }

--- a/src/components/user/UpdatePassword.tsx
+++ b/src/components/user/UpdatePassword.tsx
@@ -23,7 +23,10 @@ const useStyles = makeStyles({
 export default function UpdatePassword(props: { id: number }) {
   const { api } = useDataApiWithFeedback();
   const sendPasswordUpdate = (password: string) => {
-    return api('Updated Password').updatePassword({ id: props.id, password });
+    return api({ toastSuccessMessage: 'Updated Password' }).updatePassword({
+      id: props.id,
+      password,
+    });
   };
 
   const classes = useStyles();

--- a/src/components/user/UpdateUserInformation.tsx
+++ b/src/components/user/UpdateUserInformation.tsx
@@ -142,7 +142,9 @@ export default function UpdateUserInformation(props: { id: number }) {
   }
 
   const sendUserUpdate = (variables: UpdateUserMutationVariables) => {
-    return api('Updated Information').updateUser(variables);
+    return api({ toastSuccessMessage: 'Updated Information' }).updateUser(
+      variables
+    );
   };
 
   const isUserOfficer = currentRole === UserRole.USER_OFFICER;
@@ -150,7 +152,9 @@ export default function UpdateUserInformation(props: { id: number }) {
   const handleSetUserEmailVerified = async () => {
     const {
       setUserEmailVerified: { rejection },
-    } = await api('Email verified').setUserEmailVerified({ id: props.id });
+    } = await api({
+      toastSuccessMessage: 'Email verified',
+    }).setUserEmailVerified({ id: props.id });
 
     if (!rejection) {
       setUserData((userData) =>
@@ -167,7 +171,9 @@ export default function UpdateUserInformation(props: { id: number }) {
   const handleSetUserNotPlaceholder = async () => {
     const {
       setUserNotPlaceholder: { rejection },
-    } = await api('User is no longer placeholder').setUserNotPlaceholder({
+    } = await api({
+      toastSuccessMessage: 'User is no longer placeholder',
+    }).setUserNotPlaceholder({
       id: props.id,
     });
 

--- a/src/components/user/UpdateUserRoles.tsx
+++ b/src/components/user/UpdateUserRoles.tsx
@@ -30,10 +30,11 @@ export default function UpdateUserRoles(props: { id: number }) {
       roles: newRoles.map((role) => role.id),
     };
 
-    await api(
-      'Roles updated successfully! Any logged in users will still have old permissions until they log back in.',
-      'warning'
-    ).updateUserRoles(variables);
+    await api({
+      toastSuccessMessage:
+        'Roles updated successfully! Any logged in users will still have old permissions until they log back in.',
+      toastSuccessMessageVariant: 'warning',
+    }).updateUserRoles(variables);
 
     if (props.id === user.id) {
       setRenewTokenValue();

--- a/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
+++ b/src/hooks/settings/usePersistProposalWorkflowEditorModel.ts
@@ -19,7 +19,9 @@ export function usePersistProposalWorkflowEditorModel() {
     name: string,
     description: string
   ) => {
-    return api('Proposal workflow updated successfully!')
+    return api({
+      toastSuccessMessage: 'Proposal workflow updated successfully!',
+    })
       .updateProposalWorkflow({
         id,
         name,
@@ -52,7 +54,7 @@ export function usePersistProposalWorkflowEditorModel() {
       nextProposalStatusId: number,
       prevProposalStatusId: number
     ) => {
-      return api('Workflow status added successfully')
+      return api({ toastSuccessMessage: 'Workflow status added successfully' })
         .addProposalWorkflowStatus({
           proposalWorkflowId,
           sortOrder,
@@ -70,7 +72,9 @@ export function usePersistProposalWorkflowEditorModel() {
       to: IndexWithGroupId,
       proposalWorkflowId: number
     ) => {
-      return api('Workflow statuses reordered successfully')
+      return api({
+        toastSuccessMessage: 'Workflow statuses reordered successfully',
+      })
         .moveProposalWorkflowStatus({
           from,
           to,
@@ -84,7 +88,9 @@ export function usePersistProposalWorkflowEditorModel() {
       proposalWorkflowId: number,
       sortOrder: number
     ) => {
-      return api('Workflow status removed successfully')
+      return api({
+        toastSuccessMessage: 'Workflow status removed successfully',
+      })
         .deleteProposalWorkflowStatus({
           proposalStatusId,
           proposalWorkflowId,
@@ -97,7 +103,9 @@ export function usePersistProposalWorkflowEditorModel() {
       proposalWorkflowConnectionId: number,
       statusChangingEvents: string[]
     ) => {
-      return api('Status changing events added successfully!')
+      return api({
+        toastSuccessMessage: 'Status changing events added successfully!',
+      })
         .addStatusChangingEventsToConnection({
           proposalWorkflowConnectionId,
           statusChangingEvents,

--- a/src/units/UnitMergeReview.tsx
+++ b/src/units/UnitMergeReview.tsx
@@ -60,7 +60,7 @@ export function UnitMergeReview(props: UnitMergeReviewProps) {
   );
 
   const handleImportClick = () =>
-    api('Units imported successfully')
+    api({ toastSuccessMessage: 'Units imported successfully' })
       .importUnits({
         json,
         conflictResolutions: state.unitComparisons.map(

--- a/src/utils/useDataApiWithFeedback.ts
+++ b/src/utils/useDataApiWithFeedback.ts
@@ -1,4 +1,4 @@
-import { useSnackbar, VariantType } from 'notistack';
+import { SnackbarAction, useSnackbar, VariantType } from 'notistack';
 import { useCallback, useContext, useState } from 'react';
 
 import { UserContext } from 'context/UserContextProvider';
@@ -18,7 +18,12 @@ function useDataApiWithFeedback() {
   const { handleLogout } = useContext(UserContext);
 
   const api = useCallback(
-    (toastMessage?: string, toastMessageVariant?: VariantType) =>
+    (props?: {
+      toastSuccessMessage?: string;
+      toastErrorMessage?: string;
+      toastSuccessMessageVariant?: VariantType;
+      toastErrorMessageAction?: SnackbarAction;
+    }) =>
       new Proxy(dataApi(), {
         get(target, prop) {
           return async (args: never) => {
@@ -36,15 +41,16 @@ function useDataApiWithFeedback() {
                   reason =
                     'Your session has expired, you will need to log in again through the external homepage';
                 }
-                enqueueSnackbar(reason, {
+                enqueueSnackbar(props?.toastErrorMessage ?? reason, {
                   variant: 'error',
                   className: 'snackbar-error',
                   autoHideDuration: 10000,
+                  action: props?.toastErrorMessageAction,
                 });
               } else {
-                toastMessage &&
-                  enqueueSnackbar(toastMessage, {
-                    variant: toastMessageVariant ?? 'success',
+                props?.toastSuccessMessage &&
+                  enqueueSnackbar(props.toastSuccessMessage, {
+                    variant: props.toastSuccessMessageVariant ?? 'success',
                     className: 'snackbar-success',
                     autoHideDuration: 10000,
                   });


### PR DESCRIPTION
## Description

This makes reordering of the proposals inside SEP meeting components much easier and smooth.

## Motivation and Context

Previously it was quite hard to perceive what happened after reorder or before the dropping of the proposal to some new place.

## How Has This Been Tested

- manual tests
- e2e tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2502

## Changes

https://user-images.githubusercontent.com/6333063/165080109-b03e7741-3160-485e-8709-3f3b1010bf72.mp4

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
