### PR TITLE
feat: Use standard deviation as second sort parameter when initially sorted before ranking

### DIFF
--- a/cypress/integration/SEP.ts
+++ b/cypress/integration/SEP.ts
@@ -903,6 +903,137 @@ context('SEP meeting components tests', () => {
         .contains(proposal1.title);
     });
 
+    it('Proposals in SEP meeting components should be ordered by standard deviation as second order parameter if there is no ranking', () => {
+      cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
+        const createdProposal = result.createProposal.proposal;
+        if (createdProposal) {
+          cy.updateProposal({
+            proposalPk: createdProposal.primaryKey,
+            title: proposal2.title,
+            proposerId: initialDBData.users.user1.id,
+          });
+
+          cy.addProposalTechnicalReview({
+            proposalPk: createdProposal.primaryKey,
+            status: TechnicalReviewStatus.FEASIBLE,
+            timeAllocation: 5,
+            submitted: true,
+            reviewerId: 0,
+          });
+
+          cy.assignProposalsToInstrument({
+            instrumentId: createdInstrumentId,
+            proposals: [
+              {
+                callId: initialDBData.call.id,
+                primaryKey: createdProposal.primaryKey,
+              },
+            ],
+          });
+
+          cy.assignProposalsToSep({
+            sepId: createdSepId,
+            proposals: [
+              {
+                callId: initialDBData.call.id,
+                primaryKey: createdProposal.primaryKey,
+              },
+            ],
+          });
+
+          cy.assignReviewersToSep({
+            sepId: createdSepId,
+            memberIds: [sepMembers.reviewer2.id],
+          });
+          cy.assignSepReviewersToProposal({
+            sepId: createdSepId,
+            memberIds: [sepMembers.reviewer2.id],
+            proposalPk: createdProposalPk,
+          });
+          cy.assignReviewersToSep({
+            sepId: createdSepId,
+            memberIds: [sepMembers.reviewer.id],
+          });
+          cy.assignSepReviewersToProposal({
+            sepId: createdSepId,
+            memberIds: [sepMembers.reviewer.id],
+            proposalPk: createdProposal.primaryKey,
+          });
+          cy.assignReviewersToSep({
+            sepId: createdSepId,
+            memberIds: [sepMembers.reviewer2.id],
+          });
+          cy.assignSepReviewersToProposal({
+            sepId: createdSepId,
+            memberIds: [sepMembers.reviewer2.id],
+            proposalPk: createdProposal.primaryKey,
+          });
+
+          // Manually changing the proposal status to be shown in the SEPs. -------->
+          cy.changeProposalsStatus({
+            statusId: initialDBData.proposalStatuses.sepReview.id,
+            proposals: [
+              {
+                callId: initialDBData.call.id,
+                primaryKey: createdProposal.primaryKey,
+              },
+            ],
+          });
+
+          cy.getProposalReviews({
+            proposalPk: createdProposalPk,
+          }).then(({ proposalReviews }) => {
+            if (proposalReviews) {
+              proposalReviews.forEach((review, index) => {
+                cy.updateReview({
+                  reviewID: review.id,
+                  comment: faker.random.words(5),
+                  // NOTE: Make first proposal with lower standard deviation. Grades are 2 and 4
+                  grade: index ? 2 : 4,
+                  status: ReviewStatus.SUBMITTED,
+                  sepID: createdSepId,
+                });
+              });
+            }
+          });
+
+          cy.getProposalReviews({
+            proposalPk: createdProposal.primaryKey,
+          }).then(({ proposalReviews }) => {
+            if (proposalReviews) {
+              proposalReviews.forEach((review, index) => {
+                cy.updateReview({
+                  reviewID: review.id,
+                  comment: faker.random.words(5),
+                  // NOTE: Make second proposal with higher standard deviation. Grades are 1 and 5
+                  grade: index ? 1 : 5,
+                  status: ReviewStatus.SUBMITTED,
+                  sepID: createdSepId,
+                });
+              });
+            }
+          });
+        }
+      });
+      cy.login('officer');
+      cy.visit(`/SEPPage/${createdSepId}?tab=3`);
+
+      cy.finishedLoading();
+
+      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
+
+      cy.finishedLoading();
+
+      // NOTE: Proposal with higher standard deviation but same average score should be shown first on initial sort
+      cy.get('[data-cy="sep-instrument-proposals-table"] tbody tr')
+        .first()
+        .contains(proposal2.title);
+
+      cy.get('[data-cy="sep-instrument-proposals-table"] tbody tr')
+        .last()
+        .contains(proposal1.title);
+    });
+
     it('Officer should be able to see proposals that are marked red if they do not fit in availability time', () => {
       cy.login('officer');
       cy.visit(`/SEPPage/${createdSepId}?tab=3`);

--- a/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
+++ b/src/components/SEP/MeetingComponents/ProposalViewModal/SEPMeetingProposalViewModal.tsx
@@ -138,7 +138,9 @@ const SEPMeetingProposalViewModal: React.FC<
                         meetingSubmitted(data);
                       }}
                     />
-                    <ProposalDetails proposal={proposalData} />
+                    <ExternalReviews
+                      reviews={proposalData.reviews as Review[]}
+                    />
                     <TechnicalReviewInfo
                       hasWriteAccess={finalHasWriteAccess}
                       technicalReview={
@@ -154,9 +156,7 @@ const SEPMeetingProposalViewModal: React.FC<
                       proposal={proposalData}
                       sepId={sepId}
                     />
-                    <ExternalReviews
-                      reviews={proposalData.reviews as Review[]}
-                    />
+                    <ProposalDetails proposal={proposalData} />
                   </>
                 )}
               </div>


### PR DESCRIPTION
## Description

Use standard deviation as second sorting argument initially when proposals don't have any ranking.

## Motivation and Context

Proposals were sorted only by average score and if there are two or more proposals with same average score there was nothing else that decides which one goes first. Now standard deviation is counted as second sorting parameter.

## How Has This Been Tested

- e2e test
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2499

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
