### PR TITLE
feat: Use settings formats instead of hardcoding into the initialDBData

### DIFF
--- a/cypress/integration/calls.ts
+++ b/cypress/integration/calls.ts
@@ -75,7 +75,6 @@ context('Calls tests', () => {
 
   beforeEach(() => {
     cy.resetDB();
-    cy.getAndStoreAppSettings();
     cy.createTemplate({
       groupId: TemplateGroupId.PROPOSAL_ESI,
       name: esiTemplateName,

--- a/cypress/integration/calls.ts
+++ b/cypress/integration/calls.ts
@@ -75,6 +75,7 @@ context('Calls tests', () => {
 
   beforeEach(() => {
     cy.resetDB();
+    cy.getAndStoreAppSettings();
     cy.createTemplate({
       groupId: TemplateGroupId.PROPOSAL_ESI,
       name: esiTemplateName,
@@ -115,20 +116,21 @@ context('Calls tests', () => {
     });
 
     it('A user-officer should not be able go to next step or create call if there is validation error', () => {
+      console.log(initialDBData.formats().dateTimeFormat);
       const shortCode = faker.random.alphaNumeric(15);
       const startDate = DateTime.fromJSDate(faker.date.past()).toFormat(
-        initialDBData.formats.dateTimeFormat
+        initialDBData.formats().dateTimeFormat
       );
       const endDate = DateTime.fromJSDate(faker.date.future()).toFormat(
-        initialDBData.formats.dateTimeFormat
+        initialDBData.formats().dateTimeFormat
       );
 
       const invalidPastDate = DateTime.fromJSDate(faker.date.past()).toFormat(
-        initialDBData.formats.dateFormat + ' HH'
+        initialDBData.formats().dateFormat + ' HH'
       ); // no minutes
       const invalidFutureDate = DateTime.fromJSDate(
         faker.date.future()
-      ).toFormat(initialDBData.formats.dateFormat + ' HH'); // no minutes
+      ).toFormat(initialDBData.formats().dateFormat + ' HH'); // no minutes
 
       cy.contains('Proposals');
 
@@ -224,7 +226,7 @@ context('Calls tests', () => {
         .plus({ days: 1 })
         .startOf('day')
         // TODO: Find a way how to access the settings format here and not hard coding it like this.
-        .toFormat(initialDBData.formats.dateTimeFormat)
+        .toFormat(initialDBData.formats().dateTimeFormat)
         .toString();
 
       cy.contains('Proposals');
@@ -262,10 +264,10 @@ context('Calls tests', () => {
         newCall;
       const callShortCode = shortCode || faker.lorem.word(10);
       const callStartDate = startCall.toFormat(
-        initialDBData.formats.dateTimeFormat
+        initialDBData.formats().dateTimeFormat
       );
       const callEndDate = endCall.toFormat(
-        initialDBData.formats.dateTimeFormat
+        initialDBData.formats().dateTimeFormat
       );
       const callSurveyComment = faker.lorem.word(10);
       const callCycleComment = faker.lorem.word(10);
@@ -324,10 +326,10 @@ context('Calls tests', () => {
     it('A user-officer should be able to edit a call', () => {
       const { shortCode, startDate, endDate } = updatedCall;
       const updatedCallStartDate = startDate.toFormat(
-        initialDBData.formats.dateTimeFormat
+        initialDBData.formats().dateTimeFormat
       );
       const updatedCallEndDate = endDate.toFormat(
-        initialDBData.formats.dateTimeFormat
+        initialDBData.formats().dateTimeFormat
       );
 
       const refNumFormat = '211{digits:5}';

--- a/cypress/integration/calls.ts
+++ b/cypress/integration/calls.ts
@@ -116,21 +116,20 @@ context('Calls tests', () => {
     });
 
     it('A user-officer should not be able go to next step or create call if there is validation error', () => {
-      console.log(initialDBData.formats().dateTimeFormat);
       const shortCode = faker.random.alphaNumeric(15);
       const startDate = DateTime.fromJSDate(faker.date.past()).toFormat(
-        initialDBData.formats().dateTimeFormat
+        initialDBData.getFormats().dateTimeFormat
       );
       const endDate = DateTime.fromJSDate(faker.date.future()).toFormat(
-        initialDBData.formats().dateTimeFormat
+        initialDBData.getFormats().dateTimeFormat
       );
 
       const invalidPastDate = DateTime.fromJSDate(faker.date.past()).toFormat(
-        initialDBData.formats().dateFormat + ' HH'
+        initialDBData.getFormats().dateFormat + ' HH'
       ); // no minutes
       const invalidFutureDate = DateTime.fromJSDate(
         faker.date.future()
-      ).toFormat(initialDBData.formats().dateFormat + ' HH'); // no minutes
+      ).toFormat(initialDBData.getFormats().dateFormat + ' HH'); // no minutes
 
       cy.contains('Proposals');
 
@@ -226,7 +225,7 @@ context('Calls tests', () => {
         .plus({ days: 1 })
         .startOf('day')
         // TODO: Find a way how to access the settings format here and not hard coding it like this.
-        .toFormat(initialDBData.formats().dateTimeFormat)
+        .toFormat(initialDBData.getFormats().dateTimeFormat)
         .toString();
 
       cy.contains('Proposals');
@@ -264,10 +263,10 @@ context('Calls tests', () => {
         newCall;
       const callShortCode = shortCode || faker.lorem.word(10);
       const callStartDate = startCall.toFormat(
-        initialDBData.formats().dateTimeFormat
+        initialDBData.getFormats().dateTimeFormat
       );
       const callEndDate = endCall.toFormat(
-        initialDBData.formats().dateTimeFormat
+        initialDBData.getFormats().dateTimeFormat
       );
       const callSurveyComment = faker.lorem.word(10);
       const callCycleComment = faker.lorem.word(10);
@@ -326,10 +325,10 @@ context('Calls tests', () => {
     it('A user-officer should be able to edit a call', () => {
       const { shortCode, startDate, endDate } = updatedCall;
       const updatedCallStartDate = startDate.toFormat(
-        initialDBData.formats().dateTimeFormat
+        initialDBData.getFormats().dateTimeFormat
       );
       const updatedCallEndDate = endDate.toFormat(
-        initialDBData.formats().dateTimeFormat
+        initialDBData.getFormats().dateTimeFormat
       );
 
       const refNumFormat = '211{digits:5}';

--- a/cypress/integration/eventLogs.ts
+++ b/cypress/integration/eventLogs.ts
@@ -5,12 +5,9 @@ import { UpdateUserMutationVariables, User } from '../../src/generated/sdk';
 import initialDBData from '../support/initialDBData';
 
 context('Event log tests', () => {
-  before(() => {
-    cy.resetDB();
-  });
-
   beforeEach(() => {
     cy.resetDB();
+    cy.getAndStoreAppSettings();
   });
 
   describe('Proposal event logs', () => {
@@ -56,7 +53,7 @@ context('Event log tests', () => {
       const newFirstName = faker.name.firstName();
       // NOTE: Hour date format is enough because we don't know the exact time in seconds and minutes when update will happen in the database.
       const updateProfileDate = DateTime.now().toFormat(
-        initialDBData.formats.dateFormat + ' HH'
+        initialDBData.formats().dateFormat + ' HH'
       );
       const loggedInUser = window.localStorage.getItem('user');
 

--- a/cypress/integration/eventLogs.ts
+++ b/cypress/integration/eventLogs.ts
@@ -7,7 +7,6 @@ import initialDBData from '../support/initialDBData';
 context('Event log tests', () => {
   beforeEach(() => {
     cy.resetDB();
-    cy.getAndStoreAppSettings();
   });
 
   describe('Proposal event logs', () => {

--- a/cypress/integration/eventLogs.ts
+++ b/cypress/integration/eventLogs.ts
@@ -53,7 +53,7 @@ context('Event log tests', () => {
       const newFirstName = faker.name.firstName();
       // NOTE: Hour date format is enough because we don't know the exact time in seconds and minutes when update will happen in the database.
       const updateProfileDate = DateTime.now().toFormat(
-        initialDBData.formats().dateFormat + ' HH'
+        initialDBData.getFormats().dateFormat + ' HH'
       );
       const loggedInUser = window.localStorage.getItem('user');
 

--- a/cypress/integration/proposal_administration.ts
+++ b/cypress/integration/proposal_administration.ts
@@ -417,7 +417,6 @@ context('Proposal administration tests', () => {
   describe('Proposal administration advanced search tests', () => {
     beforeEach(() => {
       cy.resetDB(true);
-      cy.getAndStoreAppSettings();
 
       cy.viewport(1920, 1080);
 

--- a/cypress/integration/proposal_administration.ts
+++ b/cypress/integration/proposal_administration.ts
@@ -417,6 +417,7 @@ context('Proposal administration tests', () => {
   describe('Proposal administration advanced search tests', () => {
     beforeEach(() => {
       cy.resetDB(true);
+      cy.getAndStoreAppSettings();
 
       cy.viewport(1920, 1080);
 
@@ -511,17 +512,17 @@ context('Proposal administration tests', () => {
 
       const DATE_BEFORE = DateTime.fromFormat(
         DATE_ANSWER,
-        initialDBData.formats.dateFormat
+        initialDBData.formats().dateFormat
       )
         .minus({ days: 1 })
-        .toFormat(initialDBData.formats.dateFormat);
+        .toFormat(initialDBData.formats().dateFormat);
 
       const DATE_AFTER = DateTime.fromFormat(
         DATE_ANSWER,
-        initialDBData.formats.dateFormat
+        initialDBData.formats().dateFormat
       )
         .plus({ days: 1 })
-        .toFormat(initialDBData.formats.dateFormat);
+        .toFormat(initialDBData.formats().dateFormat);
 
       cy.get('[data-cy=question-list]').click();
       cy.contains(questions.date.text).click();

--- a/cypress/integration/proposal_administration.ts
+++ b/cypress/integration/proposal_administration.ts
@@ -512,17 +512,17 @@ context('Proposal administration tests', () => {
 
       const DATE_BEFORE = DateTime.fromFormat(
         DATE_ANSWER,
-        initialDBData.formats().dateFormat
+        initialDBData.getFormats().dateFormat
       )
         .minus({ days: 1 })
-        .toFormat(initialDBData.formats().dateFormat);
+        .toFormat(initialDBData.getFormats().dateFormat);
 
       const DATE_AFTER = DateTime.fromFormat(
         DATE_ANSWER,
-        initialDBData.formats().dateFormat
+        initialDBData.getFormats().dateFormat
       )
         .plus({ days: 1 })
-        .toFormat(initialDBData.formats().dateFormat);
+        .toFormat(initialDBData.getFormats().dateFormat);
 
       cy.get('[data-cy=question-list]').click();
       cy.contains(questions.date.text).click();

--- a/cypress/integration/templates.ts
+++ b/cypress/integration/templates.ts
@@ -342,7 +342,6 @@ context('Template tests', () => {
 
   beforeEach(() => {
     cy.resetDB(true);
-    cy.getAndStoreAppSettings();
     cy.viewport(1920, 1680);
   });
 

--- a/cypress/integration/templates.ts
+++ b/cypress/integration/templates.ts
@@ -685,30 +685,30 @@ context('Template tests', () => {
     it('should render the Date field with default value and min max values when set', () => {
       let dateFieldId: string;
       const minDate = DateTime.fromJSDate(faker.date.past()).toFormat(
-        initialDBData.formats().dateFormat
+        initialDBData.getFormats().dateFormat
       );
       const earlierThanMinDate = DateTime.fromFormat(
         minDate,
-        initialDBData.formats().dateFormat
+        initialDBData.getFormats().dateFormat
       )
         .minus({ day: 1 })
-        .toFormat(initialDBData.formats().dateFormat);
+        .toFormat(initialDBData.getFormats().dateFormat);
       const maxDate = DateTime.fromJSDate(faker.date.future()).toFormat(
-        initialDBData.formats().dateFormat
+        initialDBData.getFormats().dateFormat
       );
       const laterThanMaxDate = DateTime.fromFormat(
         maxDate,
-        initialDBData.formats().dateFormat
+        initialDBData.getFormats().dateFormat
       )
         .plus({ day: 1 })
-        .toFormat(initialDBData.formats().dateFormat);
+        .toFormat(initialDBData.getFormats().dateFormat);
       const defaultDate = DateTime.now().toFormat(
-        initialDBData.formats().dateFormat
+        initialDBData.getFormats().dateFormat
       );
 
       const tomorrowDate = DateTime.now()
         .plus({ day: 1 })
-        .toFormat(initialDBData.formats().dateFormat);
+        .toFormat(initialDBData.getFormats().dateFormat);
 
       cy.login('officer');
       cy.visit('/');
@@ -1244,7 +1244,7 @@ context('Template tests', () => {
     it('User can create proposal with template', () => {
       const dateTimeFieldValue = DateTime.fromJSDate(
         faker.date.past()
-      ).toFormat(initialDBData.formats().dateTimeFormat);
+      ).toFormat(initialDBData.getFormats().dateTimeFormat);
       cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
         const createdProposal = result.createProposal.proposal;
         if (createdProposal) {

--- a/cypress/integration/templates.ts
+++ b/cypress/integration/templates.ts
@@ -342,6 +342,7 @@ context('Template tests', () => {
 
   beforeEach(() => {
     cy.resetDB(true);
+    cy.getAndStoreAppSettings();
     cy.viewport(1920, 1680);
   });
 
@@ -684,30 +685,30 @@ context('Template tests', () => {
     it('should render the Date field with default value and min max values when set', () => {
       let dateFieldId: string;
       const minDate = DateTime.fromJSDate(faker.date.past()).toFormat(
-        initialDBData.formats.dateFormat
+        initialDBData.formats().dateFormat
       );
       const earlierThanMinDate = DateTime.fromFormat(
         minDate,
-        initialDBData.formats.dateFormat
+        initialDBData.formats().dateFormat
       )
         .minus({ day: 1 })
-        .toFormat(initialDBData.formats.dateFormat);
+        .toFormat(initialDBData.formats().dateFormat);
       const maxDate = DateTime.fromJSDate(faker.date.future()).toFormat(
-        initialDBData.formats.dateFormat
+        initialDBData.formats().dateFormat
       );
       const laterThanMaxDate = DateTime.fromFormat(
         maxDate,
-        initialDBData.formats.dateFormat
+        initialDBData.formats().dateFormat
       )
         .plus({ day: 1 })
-        .toFormat(initialDBData.formats.dateFormat);
+        .toFormat(initialDBData.formats().dateFormat);
       const defaultDate = DateTime.now().toFormat(
-        initialDBData.formats.dateFormat
+        initialDBData.formats().dateFormat
       );
 
       const tomorrowDate = DateTime.now()
         .plus({ day: 1 })
-        .toFormat(initialDBData.formats.dateFormat);
+        .toFormat(initialDBData.formats().dateFormat);
 
       cy.login('officer');
       cy.visit('/');
@@ -1243,7 +1244,7 @@ context('Template tests', () => {
     it('User can create proposal with template', () => {
       const dateTimeFieldValue = DateTime.fromJSDate(
         faker.date.past()
-      ).toFormat(initialDBData.formats.dateTimeFormat);
+      ).toFormat(initialDBData.formats().dateTimeFormat);
       cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
         const createdProposal = result.createProposal.proposal;
         if (createdProposal) {

--- a/cypress/integration/units.ts
+++ b/cypress/integration/units.ts
@@ -9,6 +9,7 @@ context('Units tests', () => {
   describe('Template basic unit tests', () => {
     beforeEach(() => {
       cy.resetDB();
+      cy.getAndStoreAppSettings();
     });
 
     it('User officer can create unit', () => {
@@ -117,7 +118,7 @@ context('Units tests', () => {
       const fileName = 'units_export.json';
       const now = DateTime.now();
       const downloadFileName = `units_${now.toFormat(
-        initialDBData.formats.dateFormat
+        initialDBData.formats().dateFormat
       )}.json`;
 
       cy.login('officer');

--- a/cypress/integration/units.ts
+++ b/cypress/integration/units.ts
@@ -118,7 +118,7 @@ context('Units tests', () => {
       const fileName = 'units_export.json';
       const now = DateTime.now();
       const downloadFileName = `units_${now.toFormat(
-        initialDBData.formats().dateFormat
+        initialDBData.getFormats().dateFormat
       )}.json`;
 
       cy.login('officer');

--- a/cypress/integration/units.ts
+++ b/cypress/integration/units.ts
@@ -9,7 +9,6 @@ context('Units tests', () => {
   describe('Template basic unit tests', () => {
     beforeEach(() => {
       cy.resetDB();
-      cy.getAndStoreAppSettings();
     });
 
     it('User officer can create unit', () => {

--- a/cypress/integration/user_spec.ts
+++ b/cypress/integration/user_spec.ts
@@ -23,12 +23,15 @@ context('User tests', () => {
 
   beforeEach(() => {
     cy.resetDB();
+    cy.getAndStoreAppSettings();
 
     cy.visit('/SignUp?code=WRMVXa');
   });
 
   it('A user should be able to create a new account with mandatory fields only', () => {
-    const birthDateValue = birthDate.toFormat(initialDBData.formats.dateFormat);
+    const birthDateValue = birthDate.toFormat(
+      initialDBData.formats().dateFormat
+    );
     cy.get('[data-cy=email] input').type(email).should('have.value', email);
 
     cy.get('[data-cy=password] input')
@@ -143,7 +146,9 @@ context('User tests', () => {
 
     const middleName = faker.name.firstName();
     const preferredName = faker.name.firstName();
-    const birthDateValue = birthDate.toFormat(initialDBData.formats.dateFormat);
+    const birthDateValue = birthDate.toFormat(
+      initialDBData.formats().dateFormat
+    );
 
     //Organization detail
     const department = faker.commerce.department();

--- a/cypress/integration/user_spec.ts
+++ b/cypress/integration/user_spec.ts
@@ -30,7 +30,7 @@ context('User tests', () => {
 
   it('A user should be able to create a new account with mandatory fields only', () => {
     const birthDateValue = birthDate.toFormat(
-      initialDBData.formats().dateFormat
+      initialDBData.getFormats().dateFormat
     );
     cy.get('[data-cy=email] input').type(email).should('have.value', email);
 
@@ -163,7 +163,7 @@ context('User tests', () => {
     const middleName = faker.name.firstName();
     const preferredName = faker.name.firstName();
     const birthDateValue = birthDate.toFormat(
-      initialDBData.formats().dateFormat
+      initialDBData.getFormats().dateFormat
     );
 
     //Organization detail

--- a/cypress/integration/user_spec.ts
+++ b/cypress/integration/user_spec.ts
@@ -23,7 +23,6 @@ context('User tests', () => {
 
   beforeEach(() => {
     cy.resetDB();
-    cy.getAndStoreAppSettings();
 
     cy.visit('/SignUp?code=WRMVXa');
   });

--- a/cypress/integration/visits.ts
+++ b/cypress/integration/visits.ts
@@ -155,10 +155,10 @@ context('visits tests', () => {
 
   it('Visitor should be able to register for a visit', () => {
     const startDate = DateTime.fromJSDate(faker.date.past()).toFormat(
-      initialDBData.formats().dateFormat
+      initialDBData.getFormats().dateFormat
     );
     const endDate = DateTime.fromJSDate(faker.date.future()).toFormat(
-      initialDBData.formats().dateFormat
+      initialDBData.getFormats().dateFormat
     );
 
     cy.createTemplate({

--- a/cypress/integration/visits.ts
+++ b/cypress/integration/visits.ts
@@ -16,7 +16,6 @@ context('visits tests', () => {
 
   beforeEach(() => {
     cy.resetDB(true);
-    cy.getAndStoreAppSettings();
     cy.updateProposal({
       proposalPk: existingProposalId,
       proposerId: PI.id,

--- a/cypress/integration/visits.ts
+++ b/cypress/integration/visits.ts
@@ -16,6 +16,7 @@ context('visits tests', () => {
 
   beforeEach(() => {
     cy.resetDB(true);
+    cy.getAndStoreAppSettings();
     cy.updateProposal({
       proposalPk: existingProposalId,
       proposerId: PI.id,
@@ -154,10 +155,10 @@ context('visits tests', () => {
 
   it('Visitor should be able to register for a visit', () => {
     const startDate = DateTime.fromJSDate(faker.date.past()).toFormat(
-      initialDBData.formats.dateFormat
+      initialDBData.formats().dateFormat
     );
     const endDate = DateTime.fromJSDate(faker.date.future()).toFormat(
-      initialDBData.formats.dateFormat
+      initialDBData.formats().dateFormat
     );
 
     cy.createTemplate({

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -55,9 +55,4 @@ module.exports = (on: Cypress.PluginEvents) => {
       });
     });
   });
-
-  // NOTE: Get and store the settings into localStorage before running the tests. For now this is needed because of the "getFormats()" function used in initialDBData.
-  on('before:run', () => {
-    cy.getAndStoreAppSettings();
-  });
 };

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -55,4 +55,9 @@ module.exports = (on: Cypress.PluginEvents) => {
       });
     });
   });
+
+  // NOTE: Get and store the settings into localStorage before running the tests. For now this is needed because of the "getFormats()" function used in initialDBData.
+  on('before:run', () => {
+    cy.getAndStoreAppSettings();
+  });
 };

--- a/cypress/support/admin.ts
+++ b/cypress/support/admin.ts
@@ -1,10 +1,25 @@
+import { GetSettingsQuery, PrepareDbMutation } from '../../src/generated/sdk';
 import { getE2EApi } from './utils';
 
-const resetDB = (includeSeeds = false) => {
+const resetDB = (
+  includeSeeds = false
+): Cypress.Chainable<PrepareDbMutation> => {
   const api = getE2EApi();
   const request = api.prepareDB({ includeSeeds });
 
-  cy.wrap(request);
+  return cy.wrap(request);
+};
+
+const getAndStoreAppSettings = (): Cypress.Chainable<GetSettingsQuery> => {
+  const api = getE2EApi();
+  const request = api.getSettings().then((resp) => {
+    window.localStorage.setItem('settings', JSON.stringify(resp.settings));
+
+    return resp;
+  });
+
+  return cy.wrap(request);
 };
 
 Cypress.Commands.add('resetDB', resetDB);
+Cypress.Commands.add('getAndStoreAppSettings', getAndStoreAppSettings);

--- a/cypress/support/beforeRunHook.ts
+++ b/cypress/support/beforeRunHook.ts
@@ -1,0 +1,4 @@
+// NOTE: Get and store the settings into localStorage before running the tests. For now this is needed because of the "getFormats()" function used in initialDBData.
+Cypress.on('before:run', () => {
+  cy.getAndStoreAppSettings();
+});

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -13,6 +13,9 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
+// Import before:run hook that runs before each test suite
+import './beforeRunHook';
+
 // Import commands.js using ES2015 syntax:
 import './admin';
 import './call';

--- a/cypress/support/initialDBData.ts
+++ b/cypress/support/initialDBData.ts
@@ -1,11 +1,32 @@
-import { AllocationTimeUnits, DataType } from '../../src/generated/sdk';
+import {
+  AllocationTimeUnits,
+  DataType,
+  Settings,
+  SettingsId,
+} from '../../src/generated/sdk';
 
 // NOTE: Instruments, proposal and scheduled events are seeded only if resetDB(true).
 export default {
-  // TODO: Try to fetch the formats from the DB settings
-  formats: {
-    dateFormat: 'dd-MM-yyyy',
-    dateTimeFormat: 'dd-MM-yyyy HH:mm',
+  // NOTE: To be able to use this cy.getAndStoreAppSettings() should be called in the beforeEach section.
+  formats: () => {
+    const settings = window.localStorage.getItem('settings');
+
+    let settingsMap = new Map<SettingsId, string>();
+
+    if (settings) {
+      settingsMap = new Map(
+        JSON.parse(settings).map((setting: Settings) => [
+          setting.id,
+          setting.settingsValue,
+        ])
+      );
+    }
+
+    const dateFormat = settingsMap.get(SettingsId.DATE_FORMAT) || 'dd-MM-yyyy';
+    const dateTimeFormat =
+      settingsMap.get(SettingsId.DATE_TIME_FORMAT) || 'dd-MM-yyyy HH:mm';
+
+    return { dateFormat, dateTimeFormat };
   },
   call: {
     id: 1,

--- a/cypress/support/initialDBData.ts
+++ b/cypress/support/initialDBData.ts
@@ -8,7 +8,7 @@ import {
 // NOTE: Instruments, proposal and scheduled events are seeded only if resetDB(true).
 export default {
   // NOTE: To be able to use this cy.getAndStoreAppSettings() should be called in the beforeEach section.
-  formats: () => {
+  getFormats: () => {
     const settings = window.localStorage.getItem('settings');
 
     let settingsMap = new Map<SettingsId, string>();

--- a/cypress/types/admin.d.ts
+++ b/cypress/types/admin.d.ts
@@ -1,3 +1,5 @@
+import { GetSettingsQuery, PrepareDbMutation } from '../../src/generated/sdk';
+
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -9,7 +11,16 @@ declare global {
        * @example
        *    cy.resetDB()
        */
-      resetDB: (includeSeeds?: boolean) => void;
+      resetDB: (includeSeeds?: boolean) => Cypress.Chainable<PrepareDbMutation>;
+      /**
+       * Gets app settings and stores in the localStorage to be used inside tests.
+       *
+       * @returns {typeof getAndStoreAppSettings}
+       * @memberof Chainable
+       * @example
+       *    cy.getAndStoreAppSettings()
+       */
+      getAndStoreAppSettings: () => Cypress.Chainable<GetSettingsQuery>;
     }
   }
 }


### PR DESCRIPTION
## Description

From now on there is possibility to use database date formats in the e2e tests instead of hardcoding them. The proper use includes calling a function that is defined into the `initialDBData` file `initialDBData.formats()` which returns both `dateTimeFormat` and `dateFormat`. Also before starting a test suite where we want to use this database formats we need to use the function that initializes this database settings: `cy.getAndStoreAppSettings();`

## Motivation and Context

The date formats were hardcoded into `intialDBData` file.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2444

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
