### PR TITLE
fix: add copy to clipboar icon

### DIFF
--- a/src/components/common/CopyToClipboard.tsx
+++ b/src/components/common/CopyToClipboard.tsx
@@ -3,6 +3,8 @@ import { makeStyles } from '@mui/styles';
 import clsx from 'clsx';
 import { useSnackbar } from 'notistack';
 import React, { useState } from 'react';
+
+import { truncateString } from 'utils/truncateString';
 const useStyles = makeStyles(() => ({
   container: {
     position: 'relative',
@@ -16,8 +18,13 @@ const useStyles = makeStyles(() => ({
     position: 'absolute',
     top: 0,
     bottom: 0,
-    left: '-28px',
     transition: 'all 0.15s ease-in-out',
+  },
+  positionRight: {
+    right: '-28px',
+  },
+  positionLeft: {
+    left: '-28px',
   },
 }));
 
@@ -25,17 +32,21 @@ interface CopyToClipboardProps {
   text: string;
   children: React.ReactNode;
   successMessage?: string;
+  position?: 'right' | 'left';
 }
 const CopyToClipboard = (props: CopyToClipboardProps) => {
-  const { successMessage, children, text } = props;
+  const { successMessage, children, text, position = 'left' } = props;
   const { enqueueSnackbar } = useSnackbar();
   const [showIcon, setShowIcon] = useState(false);
   const classes = useStyles();
 
   const handleClick = () => {
-    enqueueSnackbar(successMessage ?? 'Copied to clipboard', {
-      variant: 'success',
-    });
+    enqueueSnackbar(
+      successMessage ?? `Copied to clipboard "${truncateString(text, 20)}"`,
+      {
+        variant: 'success',
+      }
+    );
     navigator.clipboard.writeText(text);
     setShowIcon(false);
   };
@@ -58,6 +69,8 @@ const CopyToClipboard = (props: CopyToClipboardProps) => {
         className={clsx({
           [classes.hidden]: !showIcon,
           [classes.copyIcon]: true,
+          [classes.positionRight]: position === 'right',
+          [classes.positionLeft]: position === 'left',
         })}
       />
     </div>

--- a/src/components/questionary/questionaryComponents/RichTextInput/RichTextInputRenderer.tsx
+++ b/src/components/questionary/questionaryComponents/RichTextInput/RichTextInputRenderer.tsx
@@ -12,7 +12,7 @@ import {
 } from 'components/questionary/QuestionaryComponentRegistry';
 import stripHtml from 'utils/stripHtml';
 
-import { addElipsis } from '../../../../utils/addElipsis';
+import { truncateString } from '../../../../utils/truncateString';
 
 export const RichTextInputRendererComponent: React.FC<{
   id: string;
@@ -32,7 +32,7 @@ export const RichTextInputRendererComponent: React.FC<{
         data-cy={`${id}_open`}
         sx={{ cursor: 'pointer', ':hover': { textDecoration: 'underline' } }}
       >
-        {`${addElipsis(stripHtml(valueToRender), 100)}`}
+        {`${truncateString(stripHtml(valueToRender), 100)}`}
       </Typography>
 
       <Dialog fullWidth maxWidth="lg" open={open} onClose={handleClose}>

--- a/src/components/template/AnswerCountDetails.tsx
+++ b/src/components/template/AnswerCountDetails.tsx
@@ -1,7 +1,8 @@
 import MaterialTable from '@material-table/core';
 import React, { useMemo } from 'react';
 
-import { TemplateCategoryId } from 'generated/sdk';
+import CopyToClipboard from 'components/common/CopyToClipboard';
+import { ProposalFragment, TemplateCategoryId } from 'generated/sdk';
 import { useProposalsData } from 'hooks/proposal/useProposalsData';
 import { useSamplesWithQuestionaryStatus } from 'hooks/sample/useSamplesWithQuestionaryStatus';
 import { useShipments } from 'hooks/shipment/useShipments';
@@ -9,7 +10,14 @@ import { QuestionWithUsage } from 'hooks/template/useQuestions';
 import { tableIcons } from 'utils/materialIcons';
 
 const proposalListColumns = [
-  { title: 'ID', field: 'proposalId' },
+  {
+    title: 'ID',
+    render: (rowData: ProposalFragment) => (
+      <CopyToClipboard text={rowData.proposalId} position="right">
+        {rowData.proposalId}
+      </CopyToClipboard>
+    ),
+  },
   { title: 'Title', field: 'title' },
 ];
 

--- a/src/utils/truncateString.ts
+++ b/src/utils/truncateString.ts
@@ -1,4 +1,4 @@
-export function addElipsis(text: string, maxLength: number) {
+export function truncateString(text: string, maxLength: number) {
   if (text.length > maxLength) {
     return `${text.substring(0, maxLength)}...`;
   }


### PR DESCRIPTION
## Description
Adding icon so it is easier to copy proposal id
![image](https://user-images.githubusercontent.com/58165815/166447103-c359605d-be0b-47db-9e46-72bc223650e3.png)

## Motivation and Context

As a user officer, I want to copy the proposal ID easier

## How Has This Been Tested

- [x] E2E
- [x] Manual tests

## Fixes

N/A


## Depends on

N/A
