### PR TITLE
feat: Add questionary preview for proposal templates

### DIFF
--- a/cypress/integration/templates.ts
+++ b/cypress/integration/templates.ts
@@ -376,7 +376,7 @@ context('Template tests', () => {
       cy.contains(newName).should('not.exist');
     });
 
-    it('User officer can modify proposal template', () => {
+    it('User officer can modify and preview proposal template', () => {
       cy.login('officer');
       cy.visit('/');
 
@@ -459,6 +459,30 @@ context('Template tests', () => {
       cy.contains('Save').click();
 
       cy.contains(textQuestion.newId);
+      /* --- */
+
+      /* Check if template preview works */
+      cy.get('[data-cy="preview-questionary-template"]').click();
+      cy.get('[aria-labelledby="preview-questionary-template-modal"]').should(
+        'exist'
+      );
+
+      cy.get('[data-cy="questionary-stepper"] button').last().click();
+
+      cy.get(
+        '[aria-labelledby="preview-questionary-template-modal"] form'
+      ).contains(booleanQuestion);
+      cy.get(
+        '[aria-labelledby="preview-questionary-template-modal"] form'
+      ).contains(intervalQuestion);
+      cy.get(
+        '[aria-labelledby="preview-questionary-template-modal"] form'
+      ).contains(numberQuestion);
+      cy.get(
+        '[aria-labelledby="preview-questionary-template-modal"] form'
+      ).contains(textQuestion.title);
+
+      cy.closeModal();
       /* --- */
 
       cy.contains(textQuestion.title).click();

--- a/src/components/proposal/ProposalContainer.tsx
+++ b/src/components/proposal/ProposalContainer.tsx
@@ -27,11 +27,14 @@ interface ProposalContainerProps {
   proposal: ProposalWithQuestionary;
   proposalUpdated?: (proposal: ProposalWithQuestionary) => void;
   elevation?: PaperProps['elevation'];
+  previewMode?: boolean;
 }
 export default function ProposalContainer(props: ProposalContainerProps) {
-  const { proposal, proposalUpdated, elevation } = props;
+  const { proposal, proposalUpdated, elevation, previewMode } = props;
 
-  const [initialState] = useState(new ProposalSubmissionState(proposal));
+  const [initialState] = useState(
+    new ProposalSubmissionState(proposal, previewMode)
+  );
 
   const eventHandlers = useEventHandlers(TemplateGroupId.PROPOSAL);
 
@@ -88,6 +91,7 @@ export default function ProposalContainer(props: ProposalContainerProps) {
           <Questionary
             title={state.proposal.title || 'New Proposal'}
             info={info}
+            previewMode={previewMode}
           />
         </StyledPaper>
       </StyledContainer>

--- a/src/components/proposal/ProposalCreate.tsx
+++ b/src/components/proposal/ProposalCreate.tsx
@@ -11,18 +11,18 @@ import { ProposalWithQuestionary } from 'models/questionary/proposal/ProposalWit
 
 import ProposalContainer from './ProposalContainer';
 
-function createProposalStub(
-  callId: number,
+export function createProposalStub(
   templateId: number,
   questionarySteps: QuestionaryStep[],
   proposer: BasicUserDetails,
-  call: Call | null
+  callId?: number,
+  call?: Call | null
 ): ProposalWithQuestionary {
   return {
     primaryKey: 0,
     title: '',
     abstract: '',
-    callId: callId,
+    callId: callId || 0,
     proposer: proposer,
     questionary: {
       questionaryId: 0,
@@ -68,11 +68,11 @@ export default function ProposalCreate() {
   return (
     <ProposalContainer
       proposal={createProposalStub(
-        parseInt(callId as string),
-        parseInt(templateId as string),
+        parseInt(templateId),
         questionarySteps,
         userData,
-        call as Call
+        parseInt(callId),
+        call
       )}
     />
   );

--- a/src/components/questionary/Questionary.tsx
+++ b/src/components/questionary/Questionary.tsx
@@ -16,9 +16,10 @@ import { QuestionaryStepButton } from './QuestionaryStepButton';
 interface QuestionaryProps {
   title: string;
   info?: JSX.Element | string;
+  previewMode?: boolean;
 }
 
-function Questionary({ title, info }: QuestionaryProps) {
+function Questionary({ title, info, previewMode = false }: QuestionaryProps) {
   const isMobile = useMediaQuery('(max-width: 500px)');
 
   const useStyles = makeStyles((theme) => ({
@@ -119,7 +120,7 @@ function Questionary({ title, info }: QuestionaryProps) {
 
     return displayElementFactory.getDisplayElement(
       currentStep,
-      stepMetadata.isReadonly && !isUserOfficer
+      (stepMetadata.isReadonly && !isUserOfficer) || previewMode
     );
   };
 

--- a/src/components/questionary/questionaries/sample/SampleQuestionaryDefinition.ts
+++ b/src/components/questionary/questionaries/sample/SampleQuestionaryDefinition.ts
@@ -3,12 +3,12 @@ import { ItemWithQuestionary } from 'models/questionary/QuestionarySubmissionSta
 
 import { QuestionaryDefinition } from '../../QuestionaryRegistry';
 import { SampleStepDisplayElementFactory } from './SampleStepDisplayElementFactory';
-import { SampleWizardStepFactory } from './SampleWizardStepFactory';
+import { StepsWizardWithoutReviewStepFactory } from './StepsWizardWithoutReviewStepFactory';
 
 export const sampleQuestionaryDefinition: QuestionaryDefinition = {
   groupId: TemplateGroupId.SAMPLE,
   displayElementFactory: new SampleStepDisplayElementFactory(),
-  wizardStepFactory: new SampleWizardStepFactory(),
+  wizardStepFactory: new StepsWizardWithoutReviewStepFactory(),
   getItemWithQuestionary(
     api: Sdk,
     sampleId: number

--- a/src/components/questionary/questionaries/sample/StepsWizardWithoutReviewStepFactory.ts
+++ b/src/components/questionary/questionaries/sample/StepsWizardWithoutReviewStepFactory.ts
@@ -3,7 +3,7 @@ import { WizardStep } from 'models/questionary/QuestionarySubmissionState';
 
 import { SampleQuestionaryWizardStep } from './SampleQuestionaryWizardStep';
 
-export class SampleWizardStepFactory {
+export class StepsWizardWithoutReviewStepFactory {
   getWizardSteps(questionarySteps: QuestionaryStep[]): WizardStep[] {
     const wizardSteps: WizardStep[] = [];
 

--- a/src/components/template/PreviewTemplateModal.tsx
+++ b/src/components/template/PreviewTemplateModal.tsx
@@ -31,8 +31,8 @@ const PreviewTemplateModal: React.FC<PreviewTemplateModalProps> = ({
 
   return (
     <Dialog
-      aria-labelledby="simple-modal-title"
-      aria-describedby="simple-modal-description"
+      aria-labelledby="preview-questionary-template-modal"
+      aria-describedby="preview-questionary-template-modal"
       open={templateId !== null}
       onClose={() => setTemplateId(null)}
       style={{ backdropFilter: 'blur(6px)' }}
@@ -54,7 +54,11 @@ const PreviewTemplateModal: React.FC<PreviewTemplateModalProps> = ({
         )}
       </DialogContent>
       <DialogActions>
-        <Button variant="text" onClick={() => setTemplateId(null)}>
+        <Button
+          variant="text"
+          onClick={() => setTemplateId(null)}
+          data-cy="close-modal"
+        >
           Close
         </Button>
       </DialogActions>

--- a/src/components/template/PreviewTemplateModal.tsx
+++ b/src/components/template/PreviewTemplateModal.tsx
@@ -1,0 +1,65 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import React, { useContext } from 'react';
+
+import UOLoader from 'components/common/UOLoader';
+import ProposalContainer from 'components/proposal/ProposalContainer';
+import { createProposalStub } from 'components/proposal/ProposalCreate';
+import { UserContext } from 'context/UserContextProvider';
+import { BasicUserDetails } from 'generated/sdk';
+import { useBlankQuestionaryStepsData } from 'hooks/questionary/useBlankQuestionaryStepsData';
+
+type PreviewTemplateModalProps = {
+  templateId: number | null;
+  setTemplateId: React.Dispatch<React.SetStateAction<number | null>>;
+};
+
+const PreviewTemplateModal: React.FC<PreviewTemplateModalProps> = ({
+  templateId,
+  setTemplateId,
+}) => {
+  const { user } = useContext(UserContext);
+
+  const { questionarySteps, loading } =
+    useBlankQuestionaryStepsData(templateId);
+
+  if (!questionarySteps?.length || !templateId) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      aria-labelledby="simple-modal-title"
+      aria-describedby="simple-modal-description"
+      open={templateId !== null}
+      onClose={() => setTemplateId(null)}
+      style={{ backdropFilter: 'blur(6px)' }}
+      maxWidth="md"
+      fullWidth
+    >
+      <DialogContent>
+        {loading ? (
+          <UOLoader />
+        ) : (
+          <ProposalContainer
+            proposal={createProposalStub(
+              templateId,
+              questionarySteps,
+              user as unknown as BasicUserDetails
+            )}
+            previewMode={true}
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button variant="text" onClick={() => setTemplateId(null)}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PreviewTemplateModal;

--- a/src/components/template/TemplateEditor.tsx
+++ b/src/components/template/TemplateEditor.tsx
@@ -267,6 +267,7 @@ export default function TemplateEditor() {
       <Tooltip title="Preview questionary">
         <IconButton
           onClick={() => setOpenedPreviewTemplateId(state.templateId)}
+          data-cy="preview-questionary-template"
         >
           <Preview />
         </IconButton>

--- a/src/components/template/TemplateEditor.tsx
+++ b/src/components/template/TemplateEditor.tsx
@@ -1,9 +1,12 @@
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
+import Preview from '@mui/icons-material/Preview';
 import Button from '@mui/material/Button';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
+import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
 import Switch from '@mui/material/Switch';
+import Tooltip from '@mui/material/Tooltip';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import makeStyles from '@mui/styles/makeStyles';
 import useTheme from '@mui/styles/useTheme';
@@ -15,6 +18,7 @@ import {
   QuestionaryStep,
   QuestionTemplateRelation,
   Template,
+  TemplateGroupId,
 } from 'generated/sdk';
 import { usePersistQuestionaryEditorModel } from 'hooks/questionary/usePersistQuestionaryEditorModel';
 import QuestionaryEditorModel, {
@@ -30,6 +34,7 @@ import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 import { MiddlewareInputParams } from 'utils/useReducerWithMiddleWares';
 import { FunctionType } from 'utils/utilTypes';
 
+import PreviewTemplateModal from './PreviewTemplateModal';
 import QuestionEditor from './QuestionEditor';
 import { QuestionPicker } from './QuestionPicker';
 import QuestionTemplateRelationEditor from './QuestionTemplateRelationEditor';
@@ -56,6 +61,9 @@ export default function TemplateEditor() {
   );
 
   const [hoveredDependency, setHoveredDependency] = useState<string>('');
+  const [openedPreviewTemplateId, setOpenedPreviewTemplateId] = useState<
+    number | null
+  >(null);
 
   const [questionPickerTopicId, setQuestionPickerTopicId] = useState<
     number | null
@@ -237,30 +245,56 @@ export default function TemplateEditor() {
       </Button>
     ) : null;
 
-  const enableReorderTopicsToggle =
-    state.steps.length > 1 ? (
-      <FormGroup
-        row
-        style={{ justifyContent: 'flex-end', paddingBottom: '25px' }}
-      >
-        <FormControlLabel
-          control={
-            <Switch
-              checked={isTopicReorderMode}
-              onChange={(): void => setIsTopicReorderMode(!isTopicReorderMode)}
-            />
-          }
-          label="Reorder topics mode"
-        />
-      </FormGroup>
-    ) : null;
+  const topControlBarElements = [];
+
+  if (state.steps.length > 1) {
+    topControlBarElements.push(
+      <FormControlLabel
+        control={
+          <Switch
+            checked={isTopicReorderMode}
+            onChange={(): void => setIsTopicReorderMode(!isTopicReorderMode)}
+          />
+        }
+        label="Reorder topics mode"
+      />
+    );
+  }
+
+  // NOTE: For now preview works on proposal templates only. Another task is added to make it work for all of the templates.
+  if (state.groupId === TemplateGroupId.PROPOSAL) {
+    topControlBarElements.push(
+      <Tooltip title="Preview questionary">
+        <IconButton
+          onClick={() => setOpenedPreviewTemplateId(state.templateId)}
+        >
+          <Preview />
+        </IconButton>
+      </Tooltip>
+    );
+  }
+
+  const topControlBar = topControlBarElements.length ? (
+    <FormGroup
+      row
+      style={{ justifyContent: 'flex-end', paddingBottom: '25px' }}
+    >
+      {topControlBarElements.map((element) => element)}
+    </FormGroup>
+  ) : null;
 
   return (
     <StyledContainer maxWidth={false}>
+      {openedPreviewTemplateId !== null && (
+        <PreviewTemplateModal
+          templateId={openedPreviewTemplateId}
+          setTemplateId={setOpenedPreviewTemplateId}
+        />
+      )}
       <TemplateMetadataEditor dispatch={dispatch} template={state} />
       <StyledPaper style={getContainerStyle()}>
         {progressJsx}
-        {enableReorderTopicsToggle}
+        {topControlBar}
         <DragDropContext onDragEnd={onDragEnd}>
           <Droppable droppableId="topics" direction="horizontal" type="topic">
             {(provided, snapshot) => (

--- a/src/context/UserContextProvider.tsx
+++ b/src/context/UserContextProvider.tsx
@@ -7,7 +7,18 @@ import { useCookies } from 'react-cookie';
 import { Role, UserRole, User } from 'generated/sdk';
 import { useUnauthorizedApi } from 'hooks/common/useDataApi';
 
-export type BasicUser = Pick<User, 'id' | 'email'>;
+export type BasicUser = Pick<
+  User,
+  | 'id'
+  | 'email'
+  | 'firstname'
+  | 'lastname'
+  | 'organisation'
+  | 'preferredname'
+  | 'placeholder'
+  | 'created'
+  | 'position'
+>;
 
 interface UserContextData {
   user: BasicUser;
@@ -37,7 +48,17 @@ enum ActionType {
 }
 
 const initUserData: UserContextData = {
-  user: { id: 0, email: '' },
+  user: {
+    id: 0,
+    email: '',
+    firstname: '',
+    lastname: '',
+    organisation: 0,
+    created: '',
+    placeholder: false,
+    preferredname: '',
+    position: '',
+  },
   token: '',
   roles: [],
   currentRole: null,

--- a/src/models/questionary/QuestionarySubmissionState.ts
+++ b/src/models/questionary/QuestionarySubmissionState.ts
@@ -2,6 +2,7 @@
 import produce, { Draft } from 'immer';
 import { Reducer } from 'react';
 
+import { StepsWizardWithoutReviewStepFactory } from 'components/questionary/questionaries/sample/StepsWizardWithoutReviewStepFactory';
 import { getQuestionaryDefinition } from 'components/questionary/QuestionaryRegistry';
 import { TemplateGroupId } from 'generated/sdk';
 import { Answer, Questionary, QuestionaryStep } from 'generated/sdk';
@@ -79,13 +80,19 @@ const clamStepIndex = (stepIndex: number, stepCount: number) => {
 
   return clamp(stepIndex, minStepIndex, maxStepIndex);
 };
+
 export abstract class QuestionarySubmissionState {
   constructor(
     public templateGroupId: TemplateGroupId,
     public initItem: ItemWithQuestionary,
-    public wizardSteps: WizardStep[] = getQuestionaryDefinition(
-      templateGroupId
-    ).wizardStepFactory.getWizardSteps(initItem.questionary.steps),
+    public isPreviewMode?: boolean,
+    public wizardSteps: WizardStep[] = isPreviewMode
+      ? new StepsWizardWithoutReviewStepFactory().getWizardSteps(
+          initItem.questionary.steps
+        )
+      : getQuestionaryDefinition(
+          templateGroupId
+        ).wizardStepFactory.getWizardSteps(initItem.questionary.steps),
     public stepIndex: number = 0,
     public isDirty: boolean = false
   ) {

--- a/src/models/questionary/proposal/ProposalSubmissionState.ts
+++ b/src/models/questionary/proposal/ProposalSubmissionState.ts
@@ -7,8 +7,11 @@ import { ProposalWithQuestionary } from './ProposalWithQuestionary';
 
 export class ProposalSubmissionState extends QuestionarySubmissionState {
   [immerable] = true;
-  constructor(public proposal: ProposalWithQuestionary) {
-    super(TemplateGroupId.PROPOSAL, proposal);
+  constructor(
+    public proposal: ProposalWithQuestionary,
+    public isPreviewMode: boolean | undefined
+  ) {
+    super(TemplateGroupId.PROPOSAL, proposal, isPreviewMode);
     this.stepIndex = this.getInitialStepIndex();
   }
 


### PR DESCRIPTION
## Description

This adds the possibility for the user officer to be able to see the questionaries' while building them. For now it works only with Proposal templates but could be extended for other templates as well.

## Motivation and Context

Previously there was no way for a user officer to preview the questionaries' that were created. You need to login as a user and start creating proposal to be able to see it how it really looks like.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2425

## Changes

https://user-images.githubusercontent.com/6333063/180430751-688974d9-174e-46aa-b2c4-e03d8f4c728d.mp4


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
