### PR TITLE
fix(instrument scientist): Show disabled Admin tab form for instrument scientst

### DIFF
--- a/cypress/integration/instruments.ts
+++ b/cypress/integration/instruments.ts
@@ -822,6 +822,39 @@ context('Instrument tests', () => {
       cy.contains('20');
     });
 
+    it('Instrument scientists should be able to see but not modify the management decision', () => {
+      cy.contains('Proposals');
+
+      selectAllProposalsFilterStatus();
+
+      cy.contains(proposal1.title)
+        .parent()
+        .find('[data-cy="edit-technical-review"]')
+        .click();
+      cy.get('[role="dialog"]').as('dialog');
+      cy.finishedLoading();
+      cy.get('@dialog').contains('Admin').click();
+
+      cy.get('@dialog')
+        .find('[data-cy="proposal-final-status"] input')
+        .should('be.disabled');
+      cy.get('@dialog')
+        .find('[data-cy="managementTimeAllocation"] input')
+        .should('be.disabled');
+      cy.get('@dialog')
+        .find('[data-cy="commentForUser"] textarea')
+        .should('be.disabled');
+      cy.get('@dialog')
+        .find('[data-cy="commentForManagement"] textarea')
+        .should('be.disabled');
+      cy.get('@dialog')
+        .find('[data-cy="is-management-decision-submitted"] input')
+        .should('be.disabled');
+      cy.get('@dialog')
+        .find('[data-cy="save-admin-decision"]')
+        .should('be.disabled');
+    });
+
     it('Technical review assignee should see edit icon if assigned to review a proposal and review is not submitted', () => {
       selectAllProposalsFilterStatus();
 

--- a/src/components/proposal/ProposalAdmin.tsx
+++ b/src/components/proposal/ProposalAdmin.tsx
@@ -10,7 +10,8 @@ import { CheckboxWithLabel, Select, TextField } from 'formik-mui';
 import React from 'react';
 import { Prompt } from 'react-router';
 
-import { ProposalEndStatus } from 'generated/sdk';
+import { useCheckAccess } from 'components/common/Can';
+import { ProposalEndStatus, UserRole } from 'generated/sdk';
 import { ProposalData } from 'hooks/proposal/useProposalData';
 import { StyledButtonContainer } from 'styles/StyledComponents';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
@@ -35,6 +36,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
   setAdministration,
 }) => {
   const { api } = useDataApiWithFeedback();
+  const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
 
   const initialValues = {
     proposalPk: data.primaryKey,
@@ -114,7 +116,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
                     name="finalStatus"
                     component={Select}
                     data-cy="proposal-final-status"
-                    disabled={isSubmitting}
+                    disabled={!isUserOfficer || isSubmitting}
                     MenuProps={{ 'data-cy': 'proposal-final-status-options' }}
                     required
                   >
@@ -136,7 +138,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
                   fullWidth
                   autoComplete="off"
                   data-cy="managementTimeAllocation"
-                  disabled={isSubmitting}
+                  disabled={!isUserOfficer || isSubmitting}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -151,7 +153,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
                   data-cy="commentForUser"
                   multiline
                   rows="4"
-                  disabled={isSubmitting}
+                  disabled={!isUserOfficer || isSubmitting}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -166,7 +168,7 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
                   data-cy="commentForManagement"
                   multiline
                   rows="4"
-                  disabled={isSubmitting}
+                  disabled={!isUserOfficer || isSubmitting}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -180,11 +182,13 @@ const ProposalAdmin: React.FC<ProposalAdminProps> = ({
                       label: 'Submitted',
                     }}
                     data-cy="is-management-decision-submitted"
+                    disabled={!isUserOfficer || isSubmitting}
                   />
+
                   <Button
-                    disabled={isSubmitting}
                     type="submit"
                     data-cy="save-admin-decision"
+                    disabled={!isUserOfficer || isSubmitting}
                   >
                     Save
                   </Button>


### PR DESCRIPTION
## Description

The admin tab was visible and looked editable even for the instrument scientists. I reverted back some changes that were done by mistake and improved it a bit. Now instrument scientists can see the admin form but not being able to change because all the fields are disabled.

## Motivation and Context

Instrument scientists should only see the decision but not edit the admin form.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2713

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
