### PR TITLE
635 co proposers update box is hidden

### DIFF
--- a/src/components/user/PeopleTable.tsx
+++ b/src/components/user/PeopleTable.tsx
@@ -362,6 +362,12 @@ const PeopleTable: React.FC<PeopleTableProps> = (props) => {
     ? ((query.offset as number) + invitedUsers.length) / (query.first as number)
     : 0;
 
+  const onClickHandlerUpdateBtn = () => {
+    if (props.onUpdate) {
+      props.onUpdate(selectedParticipants);
+    }
+  };
+
   return (
     <Formik
       initialValues={{
@@ -462,11 +468,7 @@ const PeopleTable: React.FC<PeopleTableProps> = (props) => {
                 </div>
                 <Button
                   type="button"
-                  onClick={() => {
-                    if (props.onUpdate) {
-                      props.onUpdate(selectedParticipants);
-                    }
-                  }}
+                  onClick={onClickHandlerUpdateBtn}
                   disabled={selectedParticipants.length === 0}
                   data-cy="assign-selected-users"
                 >
@@ -557,11 +559,7 @@ const PeopleTable: React.FC<PeopleTableProps> = (props) => {
             </div>
             <Button
               type="button"
-              onClick={() => {
-                if (props.onUpdate) {
-                  props.onUpdate(selectedParticipants);
-                }
-              }}
+              onClick={onClickHandlerUpdateBtn}
               disabled={selectedParticipants.length === 0}
               data-cy="assign-selected-users"
             >

--- a/src/components/user/PeopleTable.tsx
+++ b/src/components/user/PeopleTable.tsx
@@ -8,7 +8,9 @@ import { Typography } from '@mui/material';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import makeStyles from '@mui/styles/makeStyles';
+import useTheme from '@mui/styles/useTheme';
 import { Formik } from 'formik';
 import React, { useState, useEffect, useContext } from 'react';
 
@@ -78,6 +80,9 @@ const useStyles = makeStyles({
   verticalCentered: {
     display: 'flex',
     alignItems: 'center',
+  },
+  mobileUpdateButton: {
+    paddingBottom: '10px',
   },
 });
 
@@ -172,6 +177,8 @@ const PeopleTable: React.FC<PeopleTableProps> = (props) => {
     FeatureId.EMAIL_SEARCH
   )?.isEnabled;
 
+  const theme = useTheme();
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('md'));
   const api = useDataApi();
   const { isLoading } = props;
   const { usersData, loadingUsersData } = useUsersData(query);
@@ -445,6 +452,30 @@ const PeopleTable: React.FC<PeopleTableProps> = (props) => {
             />
           </DialogContent>
         </Dialog>
+
+        {!isLargeScreen && (
+          <div className={classes.mobileUpdateButton}>
+            {props.selection && (
+              <ActionButtonContainer>
+                <div className={classes.verticalCentered}>
+                  {selectedParticipants.length} user(s) selected
+                </div>
+                <Button
+                  type="button"
+                  onClick={() => {
+                    if (props.onUpdate) {
+                      props.onUpdate(selectedParticipants);
+                    }
+                  }}
+                  disabled={selectedParticipants.length === 0}
+                  data-cy="assign-selected-users"
+                >
+                  Update
+                </Button>
+              </ActionButtonContainer>
+            )}
+          </div>
+        )}
         <MaterialTable
           icons={tableIcons}
           title={
@@ -519,7 +550,7 @@ const PeopleTable: React.FC<PeopleTableProps> = (props) => {
             Toolbar: isEmailSearchEnabled ? EmailSearchBar : MTableToolbar,
           }}
         />
-        {props.selection && (
+        {isLargeScreen && props.selection && (
           <ActionButtonContainer>
             <div className={classes.verticalCentered}>
               {selectedParticipants.length} user(s) selected

--- a/src/components/user/ProposalsPeopleTable.tsx
+++ b/src/components/user/ProposalsPeopleTable.tsx
@@ -9,7 +9,9 @@ import {
   IconButton,
   Typography,
 } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import makeStyles from '@mui/styles/makeStyles';
+import useTheme from '@mui/styles/useTheme';
 import { Formik } from 'formik';
 import React, { useState, useEffect, useContext } from 'react';
 
@@ -119,6 +121,9 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
   },
+  mobileUpdateButton: {
+    paddingBottom: '10px',
+  },
   titleStyle: {
     display: 'inline',
   },
@@ -156,6 +161,8 @@ const ProposalsPeopleTable: React.FC<PeopleTableProps> = (props) => {
     refreshData: false,
   });
 
+  const theme = useTheme();
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('md'));
   const featureContext = useContext(FeatureContext);
   const isEmailInviteEnabled = !!featureContext.featuresMap.get(
     FeatureId.EMAIL_INVITE
@@ -390,6 +397,32 @@ const ProposalsPeopleTable: React.FC<PeopleTableProps> = (props) => {
               </Alert>
             )}
           </div>
+
+          {!isLargeScreen && (
+            <div className={classes.mobileUpdateButton}>
+              {props.selection && (
+                <ActionButtonContainer>
+                  <div className={classes.verticalCentered}>
+                    {selectedParticipants.length} user(s) selected
+                  </div>
+                  <Button
+                    type="button"
+                    onClick={() => {
+                      if (props.onUpdate) {
+                        props.onUpdate(selectedParticipants);
+                        setSelectedParticipants([]);
+                      }
+                    }}
+                    disabled={selectedParticipants.length === 0}
+                    data-cy="assign-selected-users"
+                  >
+                    Update
+                  </Button>
+                </ActionButtonContainer>
+              )}
+            </div>
+          )}
+
           <div data-cy="co-proposers" className={classes.tableWrapper}>
             <MaterialTable
               tableRef={tableRef}
@@ -442,7 +475,7 @@ const ProposalsPeopleTable: React.FC<PeopleTableProps> = (props) => {
                 Toolbar: EmailSearchBar,
               }}
             />
-            {props.selection && (
+            {isLargeScreen && props.selection && (
               <ActionButtonContainer>
                 <div className={classes.verticalCentered}>
                   {selectedParticipants.length} user(s) selected

--- a/src/components/user/ProposalsPeopleTable.tsx
+++ b/src/components/user/ProposalsPeopleTable.tsx
@@ -320,6 +320,13 @@ const ProposalsPeopleTable: React.FC<PeopleTableProps> = (props) => {
     ? 'Please check the spelling and if the user has registered with us. If not found, the user can be added through email invite.'
     : 'Please check the spelling and if the user has registered with us or has the correct privacy settings to be found by this search.';
 
+  const onClickHandlerUpdateBtn = () => {
+    if (props.onUpdate) {
+      props.onUpdate(selectedParticipants);
+      setSelectedParticipants([]);
+    }
+  };
+
   return (
     <Formik
       initialValues={{
@@ -407,12 +414,7 @@ const ProposalsPeopleTable: React.FC<PeopleTableProps> = (props) => {
                   </div>
                   <Button
                     type="button"
-                    onClick={() => {
-                      if (props.onUpdate) {
-                        props.onUpdate(selectedParticipants);
-                        setSelectedParticipants([]);
-                      }
-                    }}
+                    onClick={onClickHandlerUpdateBtn}
                     disabled={selectedParticipants.length === 0}
                     data-cy="assign-selected-users"
                   >
@@ -482,12 +484,7 @@ const ProposalsPeopleTable: React.FC<PeopleTableProps> = (props) => {
                 </div>
                 <Button
                   type="button"
-                  onClick={() => {
-                    if (props.onUpdate) {
-                      props.onUpdate(selectedParticipants);
-                      setSelectedParticipants([]);
-                    }
-                  }}
+                  onClick={onClickHandlerUpdateBtn}
                   disabled={selectedParticipants.length === 0}
                   data-cy="assign-selected-users"
                 >


### PR DESCRIPTION
## Description
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/635
<!--- Describe your changes in detail -->

## Motivation and Context
The co-proposers box would benefit from having ‘update’ button at the top – on a smaller screen you almost always have to scroll to find this.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Through chrome and edge responsive testing developer tools

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Fix:  https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/635
<!--- Does this fix a user story, if so add a reference here -->

## Changes

Files changed:
PeopleTable.tsx
ProposalsPeopleTable.tsx

Add medial queries to show update button on top when in small screens.
The updated button will still appear at the bottom in larger screens.

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
