### PR TITLE
#631: External auth logout doesn't work in Firefox

### DIFF
--- a/src/context/UserContextProvider.tsx
+++ b/src/context/UserContextProvider.tsx
@@ -187,21 +187,26 @@ export const UserContextProvider: React.FC = (props): JSX.Element => {
     });
   }, [setCookie, state]);
 
+  async function userLogoutHandler() {
+    const token = localStorage.getItem('token');
+    if (token) {
+      await unauthorizedApi()
+        .logout({
+          token: token,
+        })
+        .finally(() => {
+          dispatch({ type: ActionType.LOGOFFUSER, payload: null });
+        });
+    }
+  }
+
   return (
     <UserContext.Provider
       value={{
         ...state,
         handleLogin: (data): void =>
           dispatch({ type: ActionType.LOGINUSER, payload: data }),
-        handleLogout: () => {
-          if (localStorage.token) {
-            unauthorizedApi().logout({
-              token: localStorage.token,
-            });
-          }
-
-          dispatch({ type: ActionType.LOGOFFUSER, payload: null });
-        },
+        handleLogout: userLogoutHandler,
         handleRole: (role: string): void =>
           dispatch({ type: ActionType.SELECTROLE, payload: role }),
         handleNewToken: useCallback(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/631

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The logout button doesn't work using Firefox, it seems to do some kind of redirect before returning back to the proposal dashboard.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through Firefox ,  Chrome and Edge manual testing.

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
Fix: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/631

## Changes

<!--- What types of changes does your code introduce? In what place? -->
Files changed:
UserContextProvider.tsx

Moved the logout handler to a separate function. Made it none blocking and changed the logout flow so that a call to logout is completed before clearing local storage. Updated get call to local storage to use Web Storage API 


## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
