### PR TITLE
Add 'Close' button to modals to stop accidental modal dismissal

### DIFF
--- a/cypress/integration/appSettings.ts
+++ b/cypress/integration/appSettings.ts
@@ -25,7 +25,7 @@ context('App settings tests', () => {
         initialDBData.getFormats().dateTimeFormat
       );
 
-      cy.get('body').type('{esc}');
+      cy.get('[data-cy="close-modal-btn"]').click();
 
       cy.get('[data-cy="officer-menu-items"]').contains('Settings').click();
       cy.get('[data-cy="officer-menu-items"]').contains('App settings').click();

--- a/src/components/common/SuperMaterialTable.tsx
+++ b/src/components/common/SuperMaterialTable.tsx
@@ -181,12 +181,19 @@ export function SuperMaterialTable<Entry extends EntryID>({
         open={show}
         maxWidth={props.createModalSize}
         fullWidth={!!props.createModalSize}
-        onClose={() => {
+        onClose={(_, reason) => {
+          if (reason && reason == 'backdropClick') return;
+          if (reason && reason == 'escapeKeyDown') return;
           setShow(false);
           setEditObject(null);
         }}
       >
         {createModal?.(onUpdated, onCreated, editObject)}
+        <ActionButtonContainer>
+          <Button onClick={() => setShow(false)} fullWidth variant="text">
+            Close
+          </Button>
+        </ActionButtonContainer>
       </InputDialog>
       <MaterialTable
         {...props}

--- a/src/components/common/SuperMaterialTable.tsx
+++ b/src/components/common/SuperMaterialTable.tsx
@@ -190,7 +190,12 @@ export function SuperMaterialTable<Entry extends EntryID>({
       >
         {createModal?.(onUpdated, onCreated, editObject)}
         <ActionButtonContainer>
-          <Button onClick={() => setShow(false)} fullWidth variant="text">
+          <Button
+            data-cy="close-modal-btn"
+            onClick={() => setShow(false)}
+            fullWidth
+            variant="text"
+          >
             Close
           </Button>
         </ActionButtonContainer>

--- a/src/components/proposal/ParticipantModal.tsx
+++ b/src/components/proposal/ParticipantModal.tsx
@@ -1,8 +1,10 @@
 import AddBox from '@mui/icons-material/AddBox';
+import { Button } from '@mui/material';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import React from 'react';
 
+import { ActionButtonContainer } from 'components/common/ActionButtonContainer';
 import { useCheckAccess } from 'components/common/Can';
 import PeopleTable from 'components/user/PeopleTable';
 import ProposalPeopleTable from 'components/user/ProposalsPeopleTable';
@@ -51,7 +53,11 @@ function ParticipantModal(props: {
       aria-labelledby="simple-modal-title"
       aria-describedby="simple-modal-description"
       open={props.show}
-      onClose={() => props.close()}
+      onClose={(_, reason) => {
+        if (reason && reason == 'backdropClick') return;
+        if (reason && reason == 'escapeKeyDown') return;
+        props.close();
+      }}
       maxWidth="sm"
       fullWidth
     >
@@ -59,6 +65,11 @@ function ParticipantModal(props: {
         {props.participant && !isUserOfficer
           ? proposalPeopleTable
           : peopleTable}
+        <ActionButtonContainer>
+          <Button onClick={() => props.close()} fullWidth variant="text">
+            Close
+          </Button>
+        </ActionButtonContainer>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/proposal/ParticipantModal.tsx
+++ b/src/components/proposal/ParticipantModal.tsx
@@ -66,7 +66,12 @@ function ParticipantModal(props: {
           ? proposalPeopleTable
           : peopleTable}
         <ActionButtonContainer>
-          <Button onClick={() => props.close()} fullWidth variant="text">
+          <Button
+            data-cy="close-modal-btn"
+            onClick={() => props.close()}
+            fullWidth
+            variant="text"
+          >
             Close
           </Button>
         </ActionButtonContainer>


### PR DESCRIPTION
## Description

Adds in code to stop data input modals closing when a user presses the <kbd>ESC</kbd> key or if they click on the background behind the modal. Also adds in a button at the bottom of the modal to close the modal. 

The screenshots show the button being pressed down just to highlight them.
[In the USER role]
Adding/Changing PI:
<img src=https://user-images.githubusercontent.com/14167006/185257429-177d6a2c-50ce-4253-8903-0b6e994f9265.png width=50%>

Adding Co-Proposers:
<img src=https://user-images.githubusercontent.com/14167006/185257698-955260f3-0576-441f-b019-dda73f88e0a2.png  width=50%>

[In the USER OFFICER role]
Updating Calls:
<img src=https://user-images.githubusercontent.com/14167006/185258519-06bcf267-1a83-4430-95d2-8061d555bf20.png width=50%>

Updating Instruments:
<img src=https://user-images.githubusercontent.com/14167006/185258623-8fa12dca-a3d8-4c0e-ac1a-d47fda1bda7c.png width=50%>

More have also been changed. It is safe to say that any modal with any sort of input from the user now has a Close button and cannot be exited out by pressing <kbd>Esc</kbd> or clicking on the background.

## Motivation and Context

Solves the issue outlined in https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/634.


## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
 - Tested manually.
 - e2e 


## Fixes

https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/634

## Changes

<!--- What types of changes does your code introduce? In what place? -->
See Description for visual changes. Code changes are minimal. Some tweaks to button positioning could be used, but main functionality is there.

## Depends on
N/A

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
